### PR TITLE
Add printing of basic terms and predicates

### DIFF
--- a/src/smt/theory_str_noodler/inclusion_graph_node.h
+++ b/src/smt/theory_str_noodler/inclusion_graph_node.h
@@ -369,6 +369,11 @@ namespace smt::noodler {
         return predicate.to_string();
     }
 
+    std::ostream& operator<<(std::ostream& os, const Predicate& predicate) {
+        os << predicate.to_string();
+        return os;
+    }
+
     static bool operator==(const Predicate& lhs, const Predicate& rhs) { return lhs.equals(rhs); }
     static bool operator!=(const Predicate& lhs, const Predicate& rhs) { return !(lhs == rhs); }
 

--- a/src/smt/theory_str_noodler/inclusion_graph_node.h
+++ b/src/smt/theory_str_noodler/inclusion_graph_node.h
@@ -26,11 +26,27 @@
 
 namespace smt::noodler {
     enum struct PredicateType {
+        Default,
         Equation,
         Inequation,
         Contains,
         // TODO: Add additional predicate types.
     };
+
+    [[nodiscard]] std::string to_string(PredicateType predicate_type) {
+        switch (predicate_type) {
+            case PredicateType::Default:
+                return "Default";
+            case PredicateType::Equation:
+                return "Equation";
+            case PredicateType::Inequation:
+                return "Inequation";
+            case PredicateType::Contains:
+                return "Contains";
+        }
+
+        throw std::runtime_error("Unhandled predicate type passed to to_string().");
+    }
 
     enum struct BasicTermType {
         Variable,
@@ -40,6 +56,23 @@ namespace smt::noodler {
         IndexOf,
         // TODO: Add additional basic term types.
     };
+
+    [[nodiscard]] std::string to_string(BasicTermType term_type) {
+        switch (term_type) {
+            case BasicTermType::Variable:
+                return "Variable";
+            case BasicTermType::Literal:
+                return "Literal";
+            case BasicTermType::Length:
+                return "Length";
+            case BasicTermType::Substring:
+                return "Substring";
+            case BasicTermType::IndexOf:
+                return "IndexOf";
+        }
+
+        throw std::runtime_error("Unhandled basic term type passed to to_string().");
+    }
 
     class BasicTerm {
     public:
@@ -58,10 +91,36 @@ namespace smt::noodler {
             return type == other.get_type() && name == other.get_name();
         }
 
+        [[nodiscard]] std::string to_string() const {
+            switch (type) {
+                case BasicTermType::Literal: {
+                    std::string result{};
+                    if (!name.empty()) {
+                        result += "\"" + name + "\" ";
+                    }
+                    result += "(" + noodler::to_string(type) + ")";
+                    return result;
+                }
+                case BasicTermType::Variable:
+                    return name + " (" + noodler::to_string(type) + ")";
+                case BasicTermType::Length:
+                case BasicTermType::Substring:
+                case BasicTermType::IndexOf:
+                    return name + " (" + noodler::to_string(type) + ")";
+                    // TODO: Decide what will have names and when to use them.
+            }
+
+            throw std::runtime_error("Unhandled basic term type passed as 'this' to to_string().");
+        }
+
     private:
         BasicTermType type;
         std::string name;
     }; // Class BasicTerm.
+
+    [[nodiscard]] std::string to_string(const BasicTerm& basic_term) {
+        return basic_term.to_string();
+    }
 
     static bool operator==(const BasicTerm& lhs, const BasicTerm& rhs) { return lhs.equals(rhs); }
     static bool operator!=(const BasicTerm& lhs, const BasicTerm& rhs) { return !(lhs == rhs); }
@@ -86,6 +145,7 @@ namespace smt::noodler {
             Right,
         };
 
+        Predicate() : type(PredicateType::Default) {}
         explicit Predicate(const PredicateType type): type(type) {
             if (is_equation() || is_inequation()) {
                 params.resize(2);
@@ -259,12 +319,55 @@ namespace smt::noodler {
             return false;
         }
 
+        [[nodiscard]] std::string to_string() const {
+            switch (type) {
+                case PredicateType::Default: {
+                    return "Default (missing type and data)";
+                }
+                case PredicateType::Equation: {
+                    std::string result{ "Equation:" };
+                    for (const auto& item: get_left_side()) {
+                        result += " . " + item.to_string();
+                    }
+                    result += " =";
+                    for (const auto& item: get_right_side()) {
+                        result += " . " + item.to_string();
+                    }
+                    return result;
+                }
+
+                case PredicateType::Inequation: {
+                    std::string result{ "Inequation:" };
+                    for (const auto& item: get_left_side()) {
+                        result += " . " + item.to_string();
+                    }
+                    result += " !=";
+                    for (const auto& item: get_right_side()) {
+                        result += " . " + item.to_string();
+                    }
+                    return result;
+                }
+
+                // TODO: Implement prints for other predicates.
+
+                case PredicateType::Contains: {
+                    break;
+                }
+            }
+
+            throw std::runtime_error("Unhandled predicate type passed as 'this' to to_string().");
+        }
+
         // TODO: Additional operations.
 
     private:
         PredicateType type;
         std::vector<std::vector<BasicTerm>> params;
     }; // Class Predicate.
+
+    [[nodiscard]] std::string to_string(const Predicate& predicate) {
+        return predicate.to_string();
+    }
 
     static bool operator==(const Predicate& lhs, const Predicate& rhs) { return lhs.equals(rhs); }
     static bool operator!=(const Predicate& lhs, const Predicate& rhs) { return !(lhs == rhs); }

--- a/src/smt/theory_str_noodler/inclusion_graph_node.h
+++ b/src/smt/theory_str_noodler/inclusion_graph_node.h
@@ -22,6 +22,7 @@
 #include <unordered_map>
 #include <string>
 #include <string_view>
+#include <set>
 
 namespace smt::noodler {
     enum struct PredicateType {
@@ -32,8 +33,8 @@ namespace smt::noodler {
     };
 
     enum struct BasicTermType {
-        Literal,
         Variable,
+        Literal,
         Length,
         Substring,
         IndexOf,
@@ -63,6 +64,20 @@ namespace smt::noodler {
     }; // Class BasicTerm.
 
     static bool operator==(const BasicTerm& lhs, const BasicTerm& rhs) { return lhs.equals(rhs); }
+    static bool operator!=(const BasicTerm& lhs, const BasicTerm& rhs) { return !(lhs == rhs); }
+    static bool operator<(const BasicTerm& lhs, const BasicTerm& rhs) {
+        if (lhs.get_type() < rhs.get_type()) {
+            return true;
+        } else if (lhs.get_type() > rhs.get_type()) {
+            return false;
+        }
+        // Types are equal. Compare names.
+        if (lhs.get_name() < rhs.get_name()) {
+            return true;
+        }
+        return false;
+    }
+    static bool operator>(const BasicTerm& lhs, const BasicTerm& rhs) { return !(lhs < rhs); }
 
     class Predicate {
     public:
@@ -145,9 +160,9 @@ namespace smt::noodler {
          * Get unique variables on both sides of an (in)equation.
          * @return Variables in the (in)equation.
          */
-        [[nodiscard]] std::vector<BasicTerm> get_vars() const {
+        [[nodiscard]] std::set<BasicTerm> get_vars() const {
             assert(is_eq_or_ineq());
-            std::vector<BasicTerm> vars;
+            std::set<BasicTerm> vars;
             for (const auto& side: params) {
                 for (const auto &term: side) {
                     if (term.is_variable()) {
@@ -158,7 +173,7 @@ namespace smt::noodler {
                                 break;
                             }
                         }
-                        if (!found) { vars.push_back(term); }
+                        if (!found) { vars.insert(term); }
                     }
                 }
             }
@@ -170,9 +185,9 @@ namespace smt::noodler {
          * @param[in] side (In)Equation side to get variables from.
          * @return Variables in the (in)equation on specified @p side.
          */
-        [[nodiscard]] std::vector<BasicTerm> get_side_vars(const EquationSideType side) const {
+        [[nodiscard]] std::set<BasicTerm> get_side_vars(const EquationSideType side) const {
             assert(is_eq_or_ineq());
-            std::vector<BasicTerm> vars;
+            std::set<BasicTerm> vars;
             std::vector<BasicTerm> side_terms;
             switch (side) {
                 case EquationSideType::Left:
@@ -195,7 +210,7 @@ namespace smt::noodler {
                             break;
                         }
                     }
-                    if (!found) { vars.push_back(term); }
+                    if (!found) { vars.insert(term); }
                 }
             }
            return vars;
@@ -252,6 +267,7 @@ namespace smt::noodler {
     }; // Class Predicate.
 
     static bool operator==(const Predicate& lhs, const Predicate& rhs) { return lhs.equals(rhs); }
+    static bool operator!=(const Predicate& lhs, const Predicate& rhs) { return !(lhs == rhs); }
 
     class Formula {
         Formula(): predicates() {}

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -6,6 +6,7 @@ Eternal glory to Yu-Fang.
 #include <algorithm>
 #include <sstream>
 #include <iostream>
+#include <cmath>
 #include "ast/ast_pp.h"
 #include "smt/theory_str_noodler/theory_str_noodler.h"
 #include "smt/smt_context.h"

--- a/src/test/noodler/inclusion-graph-node.cc
+++ b/src/test/noodler/inclusion-graph-node.cc
@@ -59,5 +59,12 @@ TEST_CASE("Conversion to strings") {
     } } };
 
     CHECK(pred.to_string() == "Equation: . \"4\" (Literal) . x_42 (Variable) = . xyz (Variable) . y_58 (Variable)");
+
+    auto pred_ineq{ Predicate{ PredicateType::Inequation, {
+            { { BasicTermType::Literal, "4" }, { BasicTermType::Variable, "x_42" } } ,
+            { { BasicTermType::Variable, "xyz" }, { BasicTermType::Variable, "y_58" } },
+    } } };
+
+    CHECK(pred_ineq.to_string() == "Inequation: . \"4\" (Literal) . x_42 (Variable) != . xyz (Variable) . y_58 (Variable)");
 }
 

--- a/src/test/noodler/inclusion-graph-node.cc
+++ b/src/test/noodler/inclusion-graph-node.cc
@@ -8,19 +8,40 @@ using namespace smt::noodler;
 
 TEST_CASE( "Inclusion graph node", "[noodler]" ) {
     auto predicate{ Predicate(PredicateType::Equation) };
+    auto predicate_ineq{ Predicate(PredicateType::Inequation) };
     CHECK(predicate.get_type() == PredicateType::Equation);
 
     constexpr auto term_name{ "x_1" };
     auto term{ BasicTerm(BasicTermType::Variable, term_name) };
     CHECK(term.get_name() == term_name);
 
-    auto& left{predicate.get_left_side() };
+    auto& left{ predicate.get_left_side() };
     left.emplace_back(term);
     left.emplace_back( BasicTermType::Literal, "lit" );
     left.emplace_back(term);
     CHECK(predicate.mult_occurr_var_side(Predicate::EquationSideType::Left));
 
+    auto& left_alt{ predicate.get_side(Predicate::EquationSideType::Left) };
+    CHECK(left == left_alt);
+
     CHECK(predicate.is_eq_or_ineq());
-    CHECK(predicate.get_side_vars(Predicate::EquationSideType::Left) == std::vector<BasicTerm>{ term });
+    CHECK(predicate.get_side_vars(Predicate::EquationSideType::Left) == std::set<BasicTerm>{ term });
     CHECK(predicate.get_side_vars(Predicate::EquationSideType::Right).empty());
+
+    CHECK(predicate != predicate_ineq);
+
+    BasicTerm term_lit{ BasicTermType::Literal, "3"};
+    BasicTerm term_lit2{ BasicTermType::Literal, "5"};
+    BasicTerm term_var{ BasicTermType::Variable, "4"};
+    BasicTerm term_var2{ BasicTermType::Variable, "6"};
+    CHECK(term_lit < term_lit2);
+    CHECK(term_lit2 > term_lit);
+    CHECK(term_var < term_lit2);
+    CHECK(term_var < term_lit);
+    CHECK(term_var < term_var2);
+    CHECK(term_var2 > term_var);
+    CHECK(term_var == term_var);
+    CHECK(term_var2 < term_lit);
+    CHECK(term_var2 < term_lit2);
+    CHECK(term != term_var);
 }

--- a/src/test/noodler/inclusion-graph-node.cc
+++ b/src/test/noodler/inclusion-graph-node.cc
@@ -45,3 +45,19 @@ TEST_CASE( "Inclusion graph node", "[noodler]" ) {
     CHECK(term_var2 < term_lit2);
     CHECK(term != term_var);
 }
+
+TEST_CASE("Conversion to strings") {
+    CHECK(smt::noodler::to_string(BasicTermType::Literal) == "Literal");
+    CHECK(smt::noodler::to_string(BasicTermType::Variable) == "Variable");
+    CHECK(BasicTerm{ BasicTermType::Literal }.to_string() == "(Literal)");
+    CHECK(BasicTerm{ BasicTermType::Literal, "4" }.to_string() == "\"4\" (Literal)");
+    CHECK(BasicTerm{ BasicTermType::Variable, "x_42" }.to_string() == "x_42 (Variable)");
+
+    auto pred{ Predicate{ PredicateType::Equation, {
+        { { BasicTermType::Literal, "4" }, { BasicTermType::Variable, "x_42" } } ,
+        { { BasicTermType::Variable, "xyz" }, { BasicTermType::Variable, "y_58" } },
+    } } };
+
+    CHECK(pred.to_string() == "Equation: . \"4\" (Literal) . x_42 (Variable) = . xyz (Variable) . y_58 (Variable)");
+}
+


### PR DESCRIPTION
This PR implements `to_string()` methods and functions for `BasicTerm` and `Predicate`.