### PR TITLE
Change Mata remote repository source to VeriFIT/mata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "extern/lib/mata"]
 	path = extern/lib/mata
-	url = https://github.com/Adda0/mata.git
+	url = https://github.com/VeriFIT/mata.git
 	branch = z3_import


### PR DESCRIPTION
This PR redirects Mata submodule to [VeriFIT/mata](https://github.com/VeriFIT/mata/tree/z3_import).