### PR TITLE
Use shared pointers in AutomataAssignment

### DIFF
--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -7,13 +7,14 @@
 #include <set>
 #include <queue>
 #include <string>
+#include <memory>
 
 #include "formula.h"
 #include <mata/nfa.hh>
 
 namespace smt::noodler {
 
-    class AutAssignment : public std::map<BasicTerm, Mata::Nfa::Nfa> {
+    class AutAssignment : public std::unordered_map<BasicTerm, std::shared_ptr<Mata::Nfa::Nfa>> {
 
     private:
         /// Union of all alphabets of automata in the aut assignment
@@ -22,14 +23,17 @@ namespace smt::noodler {
         void update_alphabet() {
             this->alphabet.clear();
             for (const auto& pr : *this) {
-                auto alph_symbols = pr.second.alphabet == nullptr ? Mata::Nfa::OnTheFlyAlphabet::from_nfas(pr.second).get_alphabet_symbols() : pr.second.alphabet->get_alphabet_symbols();
+                auto alph_symbols = pr.second->alphabet == nullptr ? Mata::Nfa::OnTheFlyAlphabet::from_nfas(*(pr.second)).get_alphabet_symbols() : pr.second->alphabet->get_alphabet_symbols();
                 this->alphabet.insert(alph_symbols.begin(), alph_symbols.end());
             }
         }
 
     public:
-        AutAssignment(std::map<BasicTerm, Mata::Nfa::Nfa> val): 
-            std::map<BasicTerm, Mata::Nfa::Nfa>(val) { 
+        AutAssignment(std::map<BasicTerm, Mata::Nfa::Nfa> val)
+        { 
+            for (const auto &key_value : val) {
+                this->operator[](key_value.first) = std::make_shared<Mata::Nfa::Nfa>(key_value.second);
+            }
             update_alphabet();
         };
 
@@ -53,13 +57,13 @@ namespace smt::noodler {
         Mata::Nfa::Nfa get_automaton_concat(const std::vector<BasicTerm>& concat) const {
             Mata::Nfa::Nfa ret = eps_automaton();
             for(const BasicTerm& t : concat) {
-                ret = Mata::Nfa::concatenate(ret, this->at(t));  // fails when not found
+                ret = Mata::Nfa::concatenate(ret, *(this->at(t)));  // fails when not found
             }
             return ret;
         }
 
         bool is_epsilon(const BasicTerm &t) const {
-            Mata::Nfa::Nfa v = Mata::Nfa::minimize(Mata::Nfa::remove_epsilon(this->at(t))); // if we are sure that we have epsilon-free automata, we can skip remove_epsilon
+            Mata::Nfa::Nfa v = Mata::Nfa::minimize(Mata::Nfa::remove_epsilon(*(this->at(t)))); // TODO if we are sure that we have epsilon-free automata, we can skip remove_epsilon
             return v.get_num_of_trans() == 0 && v.initial.size() == 1 && v.final.size();
         }
 

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -13,7 +13,12 @@
 #include <mata/nfa.hh>
 
 namespace smt::noodler {
-
+    
+    /**
+     * hints for using AutAssignment:
+     *   - use at() instead of [] operator for getting the value, use [] only for assigning
+     *   - if you want to assign some NFA, use std::make_shared<Mata::Nfa::Nfa>(NFA)
+     */
     class AutAssignment : public std::unordered_map<BasicTerm, std::shared_ptr<Mata::Nfa::Nfa>> {
 
     private:

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -734,11 +734,11 @@ namespace smt::noodler {
             if(pr.second.size() > 0) {
                 Mata::Nfa::Nfa concat;
                 if(side == Predicate::EquationSideType::Left)
-                    concat = Mata::Nfa::concatenate(sigma_star, *(this->aut_ass[pr.first]));
+                    concat = Mata::Nfa::concatenate(sigma_star, *(this->aut_ass.at(pr.first)));
                 else 
-                    concat = Mata::Nfa::concatenate(*(this->aut_ass[pr.first]), sigma_star);
+                    concat = Mata::Nfa::concatenate(*(this->aut_ass.at(pr.first)), sigma_star);
 
-                if(Mata::Nfa::are_equivalent(*(this->aut_ass[pr.first]), concat)) {
+                if(Mata::Nfa::are_equivalent(*(this->aut_ass.at(pr.first)), concat)) {
                     res.insert(pr.first);
                 }
             }

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -272,9 +272,9 @@ namespace smt::noodler {
         Mata::Nfa::Nfa concat = Mata::Nfa::remove_epsilon(this->aut_ass.get_automaton_concat(upd));
         auto iter = this->aut_ass.find(var);
         if(iter != this->aut_ass.end()) {
-            this->aut_ass[var] = Mata::Nfa::reduce(Mata::Nfa::intersection(iter->second, concat));
+            this->aut_ass[var] = std::make_shared<Mata::Nfa::Nfa>(Mata::Nfa::reduce(Mata::Nfa::intersection(*(iter->second), concat)));
         } else {
-            this->aut_ass[var] = Mata::Nfa::reduce(concat);
+            this->aut_ass[var] = std::make_shared<Mata::Nfa::Nfa>(Mata::Nfa::reduce(concat));
         }
     }
 
@@ -734,11 +734,11 @@ namespace smt::noodler {
             if(pr.second.size() > 0) {
                 Mata::Nfa::Nfa concat;
                 if(side == Predicate::EquationSideType::Left)
-                    concat = Mata::Nfa::concatenate(sigma_star, this->aut_ass[pr.first]);
+                    concat = Mata::Nfa::concatenate(sigma_star, *(this->aut_ass[pr.first]));
                 else 
-                    concat = Mata::Nfa::concatenate(this->aut_ass[pr.first], sigma_star);
+                    concat = Mata::Nfa::concatenate(*(this->aut_ass[pr.first]), sigma_star);
 
-                if(Mata::Nfa::are_equivalent(this->aut_ass[pr.first], concat)) {
+                if(Mata::Nfa::are_equivalent(*(this->aut_ass[pr.first]), concat)) {
                     res.insert(pr.first);
                 }
             }

--- a/src/test/noodler/formula-preprocess.cpp
+++ b/src/test/noodler/formula-preprocess.cpp
@@ -85,9 +85,9 @@ TEST_CASE( "Remove regular", "[noodler]" ) {
     prep.remove_regular();
 
     AutAssignment ret = prep.get_aut_assignment();
-    CHECK(Mata::Nfa::are_equivalent(ret.at(x4), regex_to_nfa("a*")));
-    CHECK(Mata::Nfa::are_equivalent(ret.at(x5), regex_to_nfa("a*")));
-    CHECK(Mata::Nfa::are_equivalent(ret.at(x2), regex_to_nfa("(a|b)*b(a*)b")));
+    CHECK(Mata::Nfa::are_equivalent(*ret.at(x4), regex_to_nfa("a*")));
+    CHECK(Mata::Nfa::are_equivalent(*ret.at(x5), regex_to_nfa("a*")));
+    CHECK(Mata::Nfa::are_equivalent(*ret.at(x2), regex_to_nfa("(a|b)*b(a*)b")));
     CHECK(prep.get_formula().get_predicates_set() == std::set<Predicate>({eq1, eq2, ieq1}));
 
     SECTION("length vars") {
@@ -291,9 +291,9 @@ TEST_CASE( "Propagate variables", "[noodler]" ) {
     FormulaPreprocess prep_res(res_conj, aut_ass, {});
 
     AutAssignment ret = prep.get_aut_assignment();
-    CHECK(Mata::Nfa::are_equivalent(ret.at(x1), regex_to_nfa("")));
-    CHECK(Mata::Nfa::are_equivalent(ret.at(x2), regex_to_nfa("(a|b)*")));
-    CHECK(Mata::Nfa::are_equivalent(ret.at(x3), regex_to_nfa("(b|c)*")));
+    CHECK(Mata::Nfa::are_equivalent(*ret.at(x1), regex_to_nfa("")));
+    CHECK(Mata::Nfa::are_equivalent(*ret.at(x2), regex_to_nfa("(a|b)*")));
+    CHECK(Mata::Nfa::are_equivalent(*ret.at(x3), regex_to_nfa("(b|c)*")));
     CHECK(prep.get_formula().get_varmap() == prep_res.get_formula().get_varmap());
     CHECK(prep.get_formula().get_predicates_set() == prep_res.get_formula().get_predicates_set());
 }
@@ -438,7 +438,7 @@ TEST_CASE( "Reduce regular", "[noodler]" ) {
         FormulaPreprocess prep(conj, aut_ass, {});
         prep.reduce_regular_sequence(2);
         AutAssignment ret = prep.get_aut_assignment();
-        CHECK(Mata::Nfa::are_equivalent(ret.at(tmp0), regex_to_nfa("a*b*b")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(tmp0), regex_to_nfa("a*b*b")));
         CHECK(prep.get_formula().get_predicates_set() == std::set<Predicate>({ 
             Predicate(PredicateType::Inequation, std::vector<std::vector<BasicTerm>>({ std::vector<BasicTerm>({a, tmp0}), std::vector<BasicTerm>({x1, x1, x2}) })), 
             Predicate(PredicateType::Equation, std::vector<std::vector<BasicTerm>>({ std::vector<BasicTerm>({x2, x1, x2}), std::vector<BasicTerm>({b, tmp0}) })), 
@@ -452,8 +452,8 @@ TEST_CASE( "Reduce regular", "[noodler]" ) {
         FormulaPreprocess prep(conj, aut_ass, {});
         prep.reduce_regular_sequence(1);
         AutAssignment ret = prep.get_aut_assignment();
-        CHECK(Mata::Nfa::are_equivalent(ret.at(tmp0), regex_to_nfa("b*ab")));
-        CHECK(Mata::Nfa::are_equivalent(ret.at(tmp1), regex_to_nfa("(a|b)*a*")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(tmp0), regex_to_nfa("b*ab")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(tmp1), regex_to_nfa("(a|b)*a*")));
         CHECK(prep.get_formula().get_predicates_set() == std::set<Predicate>({ 
             Predicate(PredicateType::Equation, std::vector<std::vector<BasicTerm>>({ std::vector<BasicTerm>({tmp1}), std::vector<BasicTerm>({x5, x1, x2, x3}) })), 
             Predicate(PredicateType::Equation, std::vector<std::vector<BasicTerm>>({ std::vector<BasicTerm>({tmp0}), std::vector<BasicTerm>({x4, a, b}) })), 
@@ -467,8 +467,8 @@ TEST_CASE( "Reduce regular", "[noodler]" ) {
         FormulaPreprocess prep(conj, aut_ass, {x2});
         prep.reduce_regular_sequence(1);
         AutAssignment ret = prep.get_aut_assignment();
-        CHECK(Mata::Nfa::are_equivalent(ret.at(tmp0), regex_to_nfa("b*ab")));
-        CHECK(Mata::Nfa::are_equivalent(ret.at(tmp1), regex_to_nfa("(a|b)*a*")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(tmp0), regex_to_nfa("b*ab")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(tmp1), regex_to_nfa("(a|b)*a*")));
         CHECK(prep.get_formula().get_predicates_set() == std::set<Predicate>({ 
             Predicate(PredicateType::Equation, std::vector<std::vector<BasicTerm>>({ std::vector<BasicTerm>({tmp1}), std::vector<BasicTerm>({x5, x1}) })), 
             Predicate(PredicateType::Equation, std::vector<std::vector<BasicTerm>>({ std::vector<BasicTerm>({tmp0}), std::vector<BasicTerm>({x4, a, b}) })), 
@@ -513,10 +513,10 @@ TEST_CASE( "Propagate eps", "[noodler]" ) {
         FormulaPreprocess prep(conj, aut_ass, {});
         prep.propagate_eps();
         AutAssignment ret = prep.get_aut_assignment();
-        CHECK(Mata::Nfa::are_equivalent(ret.at(x1), regex_to_nfa("")));
-        CHECK(Mata::Nfa::are_equivalent(ret.at(x2), regex_to_nfa("")));
-        CHECK(Mata::Nfa::are_equivalent(ret.at(x3), regex_to_nfa("")));
-        CHECK(Mata::Nfa::are_equivalent(ret.at(x4), regex_to_nfa("")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(x1), regex_to_nfa("")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(x2), regex_to_nfa("")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(x3), regex_to_nfa("")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(x4), regex_to_nfa("")));
         CHECK(prep.get_formula().get_predicates_set() == std::set<Predicate>({ 
             Predicate(PredicateType::Equation, std::vector<std::vector<BasicTerm>>({ std::vector<BasicTerm>({b}), std::vector<BasicTerm>({x5}) })  ),
             Predicate(PredicateType::Inequation, std::vector<std::vector<BasicTerm>>({ std::vector<BasicTerm>({}), std::vector<BasicTerm>({}) })  ),
@@ -529,7 +529,7 @@ TEST_CASE( "Propagate eps", "[noodler]" ) {
         FormulaPreprocess prep(conj, aut_ass, {});
         prep.propagate_eps();
         AutAssignment ret = prep.get_aut_assignment();
-        CHECK(Mata::Nfa::are_equivalent(ret.at(x1), regex_to_nfa("")));
+        CHECK(Mata::Nfa::are_equivalent(*ret.at(x1), regex_to_nfa("")));
         CHECK(prep.get_formula().get_predicates_set() == std::set<Predicate>({ 
             Predicate(PredicateType::Equation, std::vector<std::vector<BasicTerm>>({ std::vector<BasicTerm>({b}), std::vector<BasicTerm>() })  )
         }));


### PR DESCRIPTION
This pull request changes AutomataAssignment so that instead of mapping variables to NFAs it maps variables to shared_ptr<NFA>. This is because the decision procedure would create the same automaton multiple times otherwise.