### PR TITLE
Stabilize decision procedure interface

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -61,7 +61,8 @@ namespace smt::noodler {
     DecisionProcedure::DecisionProcedure(
             const Formula &equalities, AutAssignment init_aut_ass,
             const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
-            ast_manager& m, seq_util& m_util_s) : m{ m }, m_util_s{ m_util_s } {
+            ast_manager& m, seq_util& m_util_s
+    ) : m{ m }, m_util_s{ m_util_s }, init_length_sensistive_vars{ init_length_sensitive_vars } {
         SolvingState initialWlEl;
         initialWlEl.length_sensitive_vars = init_length_sensitive_vars;
         initialWlEl.aut_ass = std::move(init_aut_ass);
@@ -353,11 +354,13 @@ namespace smt::noodler {
     }
 
     expr_ref DecisionProcedure::get_lengths() {
-        return AbstractDecisionProcedure::get_lengths();
+        return AbstractDecisionProcedure::get_lengths(); // TODO: Remove when implemented.
     }
 
     void DecisionProcedure::preprocess() {
-        AbstractDecisionProcedure::preprocess();
+        /// TODO: Run str_lit convert and connect with Vojta's preprocessing.
+
+        AbstractDecisionProcedure::preprocess(); // TODO: Remove when implemented.
     }
 
 } // namespace smt::nodler

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -58,7 +58,10 @@ namespace smt::noodler {
         return result;
     }
 
-    DecisionProcedure::DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass, const std::unordered_set<BasicTerm>& init_length_sensitive_vars) {
+    DecisionProcedure::DecisionProcedure(
+            const Formula &equalities, AutAssignment init_aut_ass,
+            const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+            ast_manager& m, seq_util& m_util_s) : m{ m }, m_util_s{ m_util_s } {
         SolvingState initialWlEl;
         initialWlEl.length_sensitive_vars = init_length_sensitive_vars;
         initialWlEl.aut_ass = std::move(init_aut_ass);
@@ -347,6 +350,14 @@ namespace smt::noodler {
         }
 
         return false;
+    }
+
+    expr_ref DecisionProcedure::get_lengths() {
+        return AbstractDecisionProcedure::get_lengths();
+    }
+
+    void DecisionProcedure::preprocess() {
+        AbstractDecisionProcedure::preprocess();
     }
 
 } // namespace smt::nodler

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -57,14 +57,14 @@ namespace smt::noodler {
         }
         return result;
     }
-    
-    DecisionProcedure::DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass, std::unordered_set<BasicTerm> init_length_sensitive_vars) {
+
+    DecisionProcedure::DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass, const std::unordered_set<BasicTerm>& init_length_sensitive_vars) {
         SolvingState initialWlEl;
-        initialWlEl.length_sensitive_vars = std::move(init_length_sensitive_vars);
+        initialWlEl.length_sensitive_vars = init_length_sensitive_vars;
         initialWlEl.aut_ass = std::move(init_aut_ass);
         // TODO the ordering of nodes_to_process right now is given by how they were added from the splitting graph, should we use something different?
-        initialWlEl.inclusion_graph = std::make_shared<Graph>(Graph::create_inclusion_graph(equalities, initialWlEl.nodes_to_process)); 
-        
+        initialWlEl.inclusion_graph = std::make_shared<Graph>(Graph::create_inclusion_graph(equalities, initialWlEl.nodes_to_process));
+
         worklist.push_back(initialWlEl);
     }
 
@@ -173,7 +173,7 @@ namespace smt::noodler {
                 // we push only those nodes which are not already in nodes_to_process
                 // if the node_to_process is on cycle, we need to do BFS
                 // if it is not on cycle, we can do DFS
-                // TODO: can we really do DFS?? 
+                // TODO: can we really do DFS??
                 element_to_process.push_unique(node, is_node_to_process_on_cycle);
             }
 
@@ -182,7 +182,7 @@ namespace smt::noodler {
              * empty elements_to_process, however, we need to remmeber the state of the algorithm, we would need to return back to noodles
              * and process them if z3 realizes that the result is actually not sat (because of lengths)
              */
-            
+
 
             if (!is_there_length_on_right) {
                 // we have no length-aware variables on the right hand side
@@ -218,7 +218,7 @@ namespace smt::noodler {
                     }
                     // insert rest of vars which were not updated into new_assignment
                     new_assignment.insert(element_to_process.aut_ass.begin(), element_to_process.aut_ass.end());
-                    SolvingState new_element(std::move(new_assignment), 
+                    SolvingState new_element(std::move(new_assignment),
                                                 element_to_process.nodes_to_process,
                                                 element_to_process.inclusion_graph,
                                                 element_to_process.length_sensitive_vars,
@@ -341,7 +341,7 @@ namespace smt::noodler {
                     // TODO: should we do something more here??
 
                 }
-                
+
                 ++noodlification_no; // TODO: when to do this increment??
             }
         }

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -18,15 +18,30 @@ namespace smt::noodler {
      */
     class AbstractDecisionProcedure {
     public:
+        /**
+         * Get lengths for problem instance.
+         * @return Conjunction of lengths of the current solution for variables in constructor
+         *  (variable renames, init length variables).
+         *
+         *  FIXME: What does the note "from handlers to rewrite predicates" mean?
+         */
+        virtual expr_ref get_lengths() {
+            throw std::runtime_error("Unimplemented");
+        }
 
-        virtual void initialize(const Instance& inst) {
-            throw std::runtime_error("Not implemented");
+        virtual void preprocess() {
+            throw std::runtime_error("Unimplemented");
         }
 
         virtual bool get_another_solution(const Instance& inst, LengthConstr& out) {
             throw std::runtime_error("Not implemented");
         }
 
+        /**
+         * Compute next solution.
+         * @return True if there is an satisfiable element in the worklist and saves the satisfying element in @c
+         *  solution.
+         */
         virtual bool compute_next_solution() {
             throw std::runtime_error("Not implemented");
         }
@@ -53,7 +68,7 @@ namespace smt::noodler {
             m_util_a(util_a)
             { }
 
-        void initialize(const Instance& inst) override {
+        void initialize(const Instance& inst) {
             this->state.add(inst, 0);
         }
 
@@ -162,12 +177,26 @@ namespace smt::noodler {
         unsigned noodlification_no = 0;
 
         std::deque<SolvingState> worklist;
-    public:
-        DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass, const std::unordered_set<BasicTerm>& init_length_sensitive_vars);
 
-        // returns true if there is something in worklist that is satisfiable and saves the satisfying element in solution
+        ast_manager& m;
+        seq_util& m_util_s;
+
+        /**
+         * Convert all string literals in formula to fresh variables with automata in automata assignment.
+         *
+         * All string literals are converted to fresh variables with assigned automata equal to the string literal
+         *  expression.
+         */
+        void conv_str_lits_to_fresh_vars();
+
+    public:
+        DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass, const std::unordered_set<BasicTerm>& init_length_sensitive_vars, ast_manager& m, seq_util& m_util_s);
+
         bool compute_next_solution() override;
-        SolvingState solution;
+        expr_ref get_lengths() override;
+        void preprocess() override;
+
+
     };
 }
 

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -13,7 +13,7 @@
 
 namespace smt::noodler {
     /**
-     * @brief Abstract decision procedure. Defines interface for decision 
+     * @brief Abstract decision procedure. Defines interface for decision
      * procedures to be used within z3.
      */
     class AbstractDecisionProcedure {
@@ -35,7 +35,7 @@ namespace smt::noodler {
     };
 
     /**
-     * @brief Debug instance of the Decision procedure. Always says SAT and return some length 
+     * @brief Debug instance of the Decision procedure. Always says SAT and return some length
      * constraints. Simulates the situation when each instance has exactly 10 noodles.
      */
     class DecisionProcedureDebug : public AbstractDecisionProcedure {
@@ -46,11 +46,11 @@ namespace smt::noodler {
         arith_util& m_util_a;
 
     public:
-        DecisionProcedureDebug(ast_manager& mn, seq_util& util_s, arith_util& util_a) : 
-            state(), 
-            m(mn), 
-            m_util_s(util_s), 
-            m_util_a(util_a) 
+        DecisionProcedureDebug(ast_manager& mn, seq_util& util_s, arith_util& util_a) :
+            state(),
+            m(mn),
+            m_util_s(util_s),
+            m_util_a(util_a)
             { }
 
         void initialize(const Instance& inst) override {
@@ -85,7 +85,7 @@ namespace smt::noodler {
         }
 
         ~DecisionProcedureDebug() { }
-    
+
     };
 
 
@@ -107,9 +107,9 @@ namespace smt::noodler {
                         std::unordered_map<BasicTerm, std::vector<BasicTerm>> substitution_map)
                         : aut_ass(aut_ass),
                           nodes_to_process(nodes_to_process),
-                          inclusion_graph(inclusion_graph), 
+                          inclusion_graph(inclusion_graph),
                           length_sensitive_vars(length_sensitive_vars),
-                          substitution_map(substitution_map) {} 
+                          substitution_map(substitution_map) {}
 
         // pushes node to the beginning of nodes_to_process but only if it is not in it yet
         void push_front_unique(const std::shared_ptr<GraphNode> &node) {
@@ -145,10 +145,10 @@ namespace smt::noodler {
 
         /**
          * @brief Combines aut_ass and substitution_map into one AutAssigment
-         * 
+         *
          * For example, if we have aut_ass[x] = aut1, aut_ass[y] = aut2, and substitution_map[z] = xy, then this will return
          * automata assignment ret_ass where ret_ass[x] = aut1, ret_ass[y] = aut2, and ret_ass[z] = concatenation(aut1, aut2)
-         * 
+         *
          */
         AutAssignment flatten_substition_map();
     };
@@ -163,9 +163,7 @@ namespace smt::noodler {
 
         std::deque<SolvingState> worklist;
     public:
-
-
-        DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass, const std::unordered_set<BasicTerm> init_length_sensitive_vars);
+        DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass, const std::unordered_set<BasicTerm>& init_length_sensitive_vars);
 
         // returns true if there is something in worklist that is satisfiable and saves the satisfying element in solution
         bool compute_next_solution() override;

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -18,8 +18,6 @@ namespace smt::noodler {
      */
     class AbstractDecisionProcedure {
     public:
-
-        /// TODO: What to do?
         virtual void preprocess() {
             throw std::runtime_error("Unimplemented");
         }
@@ -36,8 +34,6 @@ namespace smt::noodler {
          * Get lengths for problem instance.
          * @return Conjunction of lengths of the current solution for variables in constructor
          *  (variable renames, init length variables).
-         *
-         *  FIXME: What does the note "from handlers to rewrite predicates" mean?
          */
         virtual expr_ref get_lengths() {
             throw std::runtime_error("Unimplemented");
@@ -57,19 +53,14 @@ namespace smt::noodler {
         seq_util& m_util_s;
         arith_util& m_util_a;
         Instance inst{};
-        LengthConstr* out_length_constr{ nullptr };
+        LengthConstr* solution{ nullptr };
 
     public:
-        DecisionProcedureDebug(ast_manager& mn, seq_util& util_s, arith_util& util_a) :
-            state(),
-            m(mn),
-            m_util_s(util_s),
-            m_util_a(util_a)
-            { }
-
-        void initialize(const Instance& inst, LengthConstr& len) {
+        DecisionProcedureDebug(const Instance& inst, LengthConstr& len,
+                               ast_manager& mn, seq_util& util_s, arith_util& util_a
+        ) : state{}, m{ mn }, m_util_s{ util_s }, m_util_a{ util_a } {
             this->inst = inst;
-            this->out_length_constr = &len;
+            this->solution = &len;
             this->state.add(inst, 0);
         }
 
@@ -96,7 +87,7 @@ namespace smt::noodler {
             }
 
             this->state.update_val(inst, cnt+1);
-            *out_length_constr = refinement_len;
+            *solution = refinement_len;
             return true;
         }
 
@@ -177,6 +168,7 @@ namespace smt::noodler {
         // by for example setting the name to VAR_PREFIX + "_" + noodlification_no + "_" + index_in_the_noodle
         unsigned noodlification_no = 0;
 
+
         std::deque<SolvingState> worklist;
 
         /// State of a found satisfiable solution set when one is computed using
@@ -185,6 +177,7 @@ namespace smt::noodler {
 
         ast_manager& m;
         seq_util& m_util_s;
+        const std::unordered_set<BasicTerm>& init_length_sensistive_vars;
 
         /**
          * Convert all string literals in formula to fresh variables with automata in automata assignment.
@@ -195,10 +188,14 @@ namespace smt::noodler {
         void conv_str_lits_to_fresh_vars();
 
     public:
-        DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass, const std::unordered_set<BasicTerm>& init_length_sensitive_vars, ast_manager& m, seq_util& m_util_s);
+        DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass,
+                          const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+                          ast_manager& m, seq_util& m_util_s
+        );
 
         bool compute_next_solution() override;
         expr_ref get_lengths() override;
+
         void preprocess() override;
     };
 }

--- a/src/smt/theory_str_noodler/inclusion_graph.h
+++ b/src/smt/theory_str_noodler/inclusion_graph.h
@@ -4,6 +4,7 @@
 
 #include <optional>
 #include <deque>
+#include <algorithm>
 #include "formula.h"
 
 namespace smt::noodler {
@@ -162,7 +163,7 @@ namespace smt::noodler {
 
         /**
          * @brief adds node with predicate to graph (even if a node with such predicate exists in graph)
-         * 
+         *
          * @return the newly added node
          */
         std::shared_ptr<GraphNode> add_node(const Predicate& predicate) {
@@ -175,7 +176,7 @@ namespace smt::noodler {
 
         /**
          * @brief adds node with predicate to graph (even if a node with such predicate exists in graph)
-         * 
+         *
          * @return the newly added node
          */
         std::shared_ptr<GraphNode> add_node(const std::vector<BasicTerm> &left_side, const std::vector<BasicTerm> &right_side) {
@@ -192,7 +193,7 @@ namespace smt::noodler {
             return (nodes_not_on_cycle.count(node) == 0);
         }
 
-        // adds edges so that inclusions x and y where left side of x shares variable with right side of y have edge from x to y  
+        // adds edges so that inclusions x and y where left side of x shares variable with right side of y have edge from x to y
         void add_inclusion_graph_edges();
 
         // makes a deep copy of the garph, i.e. returned graph is semantically same as this graph, but the pointers to nodes are different

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -715,11 +715,11 @@ namespace smt::noodler {
         return FC_CONTINUE;
 
         if(!this->state_len.contains(conj)){
-            this->adec_proc->initialize(conj);
+            expr_ref len_constr(m);
+            this->adec_proc->initialize(conj, len_constr);
             this->state_len.add(conj, true);
 
-            expr_ref len_constr(m);
-            while(this->adec_proc->get_another_solution(conj, len_constr)) {
+            while(this->adec_proc->compute_next_solution()) {
                 if(len_constr == nullptr)
                     continue;
                 int_expr_solver m_int_solver(get_manager(), get_context().get_fparams());

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1,5 +1,5 @@
 /*
-The skeleton of this code was obtained by Yu-Fang Chen from https://github.com/guluchen/z3. 
+The skeleton of this code was obtained by Yu-Fang Chen from https://github.com/guluchen/z3.
 Eternal glory to Yu-Fang.
 */
 
@@ -26,10 +26,10 @@ namespace smt::noodler {
         bool IN_CHECK_FINAL = false;
     }
 
-    theory_str_noodler::theory_str_noodler(context& ctx, ast_manager & m, theory_str_params const & params): 
-        theory(ctx, ctx.get_manager().mk_family_id("seq")), 
+    theory_str_noodler::theory_str_noodler(context& ctx, ast_manager & m, theory_str_params const & params):
+        theory(ctx, ctx.get_manager().mk_family_id("seq")),
         m_params(params),
-        m_rewrite(m), 
+        m_rewrite(m),
         m_util_a(m),
         m_util_s(m),
         state_len(),
@@ -106,7 +106,7 @@ namespace smt::noodler {
         if (m.is_bool(term)) {
             bool_var bv = ctx.mk_bool_var(term);
             ctx.set_var_theory(bv, get_id());
-            //We do not want to mark as relevant because it involves 
+            //We do not want to mark as relevant because it involves
             // irrelevant RE solutions comming from the underlying SAT solver.
             //ctx.mark_as_relevant(bv);
         }
@@ -149,7 +149,7 @@ namespace smt::noodler {
         }
 
         return;
-        
+
         std::cout << ctx.get_unsat_core_size() << std::endl;
         std::cout << "~~~~~ print ctx start ~~~~~~~\n";
 //        context& ctx = get_context();
@@ -221,8 +221,8 @@ namespace smt::noodler {
         if (!ctx.e_internalized(expr)) {
             ctx.internalize(expr, false);
         }
-        //We do not mark the expression as relevant since we do not want bias a 
-        //fresh SAT solution by the newly added theory axioms. 
+        //We do not mark the expression as relevant since we do not want bias a
+        //fresh SAT solution by the newly added theory axioms.
         //enode *n = ctx.get_enode(expr);
         //ctx.mark_as_relevant(n);
 
@@ -297,7 +297,7 @@ namespace smt::noodler {
     void theory_str_noodler::propagate_basic_string_axioms(enode *str) {
         bool on_screen = false;
 
-        return; 
+        return;
 
         context &ctx = get_context();
         ast_manager &m = get_manager();
@@ -506,8 +506,8 @@ namespace smt::noodler {
         const expr_ref r{get_enode(y)->get_expr(), m};
 
         m_word_diseq_var_todo.push_back({x, y});
-        m_word_diseq_todo.push_back({l, r});    
-        
+        m_word_diseq_todo.push_back({l, r});
+
         app_ref l_eq_r(ctx.mk_eq_atom(l.get(), r.get()), m);
         app_ref neg(m.mk_not(l_eq_r), m);
         ctx.internalize(neg, false);
@@ -548,7 +548,7 @@ namespace smt::noodler {
         m_not_contains_todo.pop_scope(num_scopes);
         m_rewrite.reset();
         STRACE("str", if (!IN_CHECK_FINAL)
-            tout << "pop_scope: " << num_scopes << " (back to level " << m_scope_level << ")\n";);       
+            tout << "pop_scope: " << num_scopes << " (back to level " << m_scope_level << ")\n";);
     }
 
     void theory_str_noodler::reset_eh() {
@@ -585,11 +585,11 @@ namespace smt::noodler {
     }
 
     /**
-    Remove irrelevant string constraints. In particular remove equations, disequations, and 
+    Remove irrelevant string constraints. In particular remove equations, disequations, and
     regular constraints that are not relevant for SAT checking.
     */
     void theory_str_noodler::remove_irrelevant_constr() {
-        
+
         this->m_word_eq_todo_rel.clear();
         this->m_word_diseq_todo_rel.clear();
         this->m_membership_todo_rel.clear();
@@ -597,15 +597,15 @@ namespace smt::noodler {
         for (const auto& we : m_word_eq_todo) {
             app_ref eq(ctx.mk_eq_atom(we.first, we.second), m);
             if(!ctx.is_relevant(eq.get())) {
-                STRACE("str", tout << "remove_irrelevant_eqs: " << mk_pp(eq.get(), m) << " relevant: " << 
+                STRACE("str", tout << "remove_irrelevant_eqs: " << mk_pp(eq.get(), m) << " relevant: " <<
                     ctx.is_relevant(eq.get()) << " assign: " << ctx.find_assignment(eq.get()) << '\n';);
                 continue;
-            }   
+            }
 
             // app_ref double_not(m.mk_not(m.mk_not(eq)), m);
             // ctx.internalize(double_not, false);
             // if(ctx.find_assignment(double_not.get()) != l_undef && !ctx.is_relevant(double_not.get())) {
-            //     STRACE("str", tout << "remove_irrelevant_eqs: " << mk_pp(double_not.get(), m) << " relevant: " << 
+            //     STRACE("str", tout << "remove_irrelevant_eqs: " << mk_pp(double_not.get(), m) << " relevant: " <<
             //         ctx.is_relevant(double_not.get()) << " assign: " << ctx.find_assignment(double_not.get()) << '\n';);
             //     continue;
             // }
@@ -619,7 +619,7 @@ namespace smt::noodler {
             app_ref eq(ctx.mk_eq_atom(we.first, we.second), m);
             app_ref dis(m.mk_not(eq), m);
             if(!ctx.is_relevant(dis.get())) {
-                STRACE("str", tout << "remove_irrelevant NEQ: " << mk_pp(dis.get(), m) << " relevant: " << 
+                STRACE("str", tout << "remove_irrelevant NEQ: " << mk_pp(dis.get(), m) << " relevant: " <<
                     ctx.is_relevant(dis.get()) << " assign: " << ctx.find_assignment(dis.get()) << '\n';);
                 continue;
             }
@@ -634,12 +634,12 @@ namespace smt::noodler {
                 in_app = m.mk_not(in_app);
             }
             if(ctx.is_relevant(in_app.get())) {
-                STRACE("str", tout << "remove_irrelevant RE: " << mk_pp(in_app.get(), m) << " relevant: " << 
+                STRACE("str", tout << "remove_irrelevant RE: " << mk_pp(in_app.get(), m) << " relevant: " <<
                     ctx.is_relevant(in_app.get()) << " assign: " << ctx.find_assignment(in_app.get()) << '\n';);
-                
+
                 if(!this->m_membership_todo_rel.contains(we)) {
                     this->m_membership_todo_rel.push_back(we);
-                }  
+                }
                 continue;
             }
         }
@@ -699,7 +699,7 @@ namespace smt::noodler {
 
 
 
-        
+
 
         Formula instance;
         this->conj_instance(conj_instance, instance);
@@ -741,7 +741,7 @@ namespace smt::noodler {
             TRACE("str", tout << "already visited\n";);
             UNREACHABLE();
             return FC_CONTINUE;
-        }        
+        }
 
         return FC_DONE;
 
@@ -749,7 +749,7 @@ namespace smt::noodler {
         block_curr_assignment();
         TRACE("str", tout << "final_check ends\n";);
         IN_CHECK_FINAL = false;
-        
+
         return FC_CONTINUE;
     }
 
@@ -921,17 +921,17 @@ namespace smt::noodler {
 
     /**
      * @brief Handle str.at(s,i)
-     * 
+     *
      * Translates to the following theory axioms:
      * 0 <= i < |s| -> s = xvy
      * 0 <= i < |s| -> v in re.allchar
      * 0 <= i < |s| -> |x| = i
      * i < 0 -> v = eps
      * i >= |s| -> v = eps
-     * 
+     *
      * We store
      * str.at(s,i) = v
-     * 
+     *
      * @param e str.at(s, i)
      */
     void theory_str_noodler::handle_char_at(expr *e) {
@@ -973,7 +973,7 @@ namespace smt::noodler {
 
     /**
      * @brief Handle str.substr(s,i,l)
-     * 
+     *
      * Translates to the following theory axioms:
      * 0 <= i <= |s| -> x.v.y = s
      * 0 <= i <= |s| -> |x| = i
@@ -983,10 +983,10 @@ namespace smt::noodler {
      * i < 0 -> v = eps
      * not(0 <= l <= |s| - i) -> v = eps
      * i > |s| -> v = eps
-     * 
+     *
      * We store
      * substr(s, i, n) = v
-     * 
+     *
      * @param e str.substr(s, i, l)
      */
     void theory_str_noodler::handle_substr(expr *e) {
@@ -1058,7 +1058,7 @@ namespace smt::noodler {
      * contains(a,s) && a != eps && s != eps -> a = x.s.y
      * contains(a,s) && a != eps && s != eps -> v = x.t.y
      * tighttestprefix(s,t)
-     * 
+     *
      * @param r replace term
      */
     void theory_str_noodler::handle_replace(expr *r) {
@@ -1103,7 +1103,7 @@ namespace smt::noodler {
      * contains(t, s) && s != eps -> indexof = |x|
      * contains(t, s) -> indexof >= 0
      * tightestprefix(s,x)
-     * 
+     *
      * The case of offset > 0
      * not(contains(t,s)) -> indexof = -1
      * t = eps && s != eps -> indexof = -1
@@ -1115,7 +1115,7 @@ namespace smt::noodler {
      * offset >= 0 && offset < |t| && indexof(y,s,0) = -1 -> indexof = -1
      * offset >= 0 && offset < |t| && indexof(y,s,0) >= 0 -> offset + indexof(y,s,0) = indexof
      * offset < 0 -> indexof = -1
-     * 
+     *
      * @param i indexof term
      */
     void theory_str_noodler::handle_index_of(expr *i) {
@@ -1202,12 +1202,12 @@ namespace smt::noodler {
     }
 
     /**
-     * @brief String term @p x does not contain @p s as a substring. 
+     * @brief String term @p x does not contain @p s as a substring.
      * Translates to the following theory axioms:
      * not(s = eps) -> s = s1.s2 where s1 = s[0,-2], s2 = s[-1] in the case of @p s being a string
      * not(s = eps) -> not(contains(x.s1, s))
      * not(s = eps) -> s2 in re.allchar (is a single character)
-     * 
+     *
      * @param s Substring that should not be present
      * @param x String term
      */
@@ -1225,7 +1225,7 @@ namespace smt::noodler {
 
     /**
      * @brief Get string term representing first |s| - 1 characters of @p s.
-     * 
+     *
      * @param s String term
      * @return expr_ref String term
      */
@@ -1239,7 +1239,7 @@ namespace smt::noodler {
 
     /**
      * @brief Get string term representing last character of @p s.
-     * 
+     *
      * @param s String term
      * @return expr_ref String term
      */
@@ -1287,7 +1287,7 @@ namespace smt::noodler {
      * @brief Handling of str.prefix(x, y) = e (x is a prefix of y)
      * Translates to the following theory axioms:
      * e -> y = x.v
-     * 
+     *
      * @param e prefix term
      */
     void theory_str_noodler::handle_prefix(expr *e) {
@@ -1314,13 +1314,13 @@ namespace smt::noodler {
      * not(e) && |x| <= |y| -> mx in re.allchar
      * not(e) && |x| <= |y| -> my in re.allchar
      * not(e) && |x| <= |y| -> mx != my
-     * 
+     *
      * @param e prefix term
      */
     void theory_str_noodler::handle_not_prefix(expr *e) {
         if(axiomatized_terms.contains(e))
-            return; 
-            
+            return;
+
         axiomatized_terms.insert(e);
         ast_manager &m = get_manager();
         expr *x = nullptr, *y = nullptr;
@@ -1371,13 +1371,13 @@ namespace smt::noodler {
      * @brief Handling of str.suffix(x, y) = e (x is a suffix of y)
      * Translates to the following theory axioms:
      * e -> y = v.x
-     * 
+     *
      * @param e suffix term
      */
     void theory_str_noodler::handle_suffix(expr *e) {
         if(axiomatized_terms.contains(e))
             return;
-        
+
         axiomatized_terms.insert(e);
         ast_manager &m = get_manager();
         expr *x = nullptr, *y = nullptr;
@@ -1400,7 +1400,7 @@ namespace smt::noodler {
      * not(e) && |x| <= |y| -> mx in re.allchar
      * not(e) && |x| <= |y| -> my in re.allchar
      * not(e) && |x| <= |y| -> mx != my
-     * 
+     *
      * @param e prefix term
      */
     void theory_str_noodler::handle_not_suffix(expr *e) {
@@ -1457,7 +1457,7 @@ namespace smt::noodler {
      * @brief Handle contains
      * Translates to the following theory axioms:
      * str.contains(x,y) -> x = pys
-     * 
+     *
      * @param e str.contains(x,y)
      */
     void theory_str_noodler::handle_contains(expr *e) {
@@ -1479,9 +1479,9 @@ namespace smt::noodler {
 
 
     /**
-     * @brief Heuristics for handling not contains: not(contains(s, t)). 
+     * @brief Heuristics for handling not contains: not(contains(s, t)).
      * So far only the case when t is a string literal is implemented.
-     * 
+     *
      * @param e contains term.
      */
     void theory_str_noodler::handle_not_contains(expr *e) {
@@ -1490,12 +1490,12 @@ namespace smt::noodler {
 
         axiomatized_terms.insert(e);
         expr *x = nullptr, *y = nullptr;
-        VERIFY(m_util_s.str.is_contains(e, x, y)); 
+        VERIFY(m_util_s.str.is_contains(e, x, y));
 
         zstring s;
         if(m_util_s.str.is_string(y, s)) {
-            expr_ref re(m_util_s.re.mk_in_re(x, m_util_s.re.mk_concat(m_util_s.re.mk_star(m_util_s.re.mk_full_char(nullptr)), 
-                m_util_s.re.mk_concat(m_util_s.re.mk_to_re(m_util_s.str.mk_string(s)), 
+            expr_ref re(m_util_s.re.mk_in_re(x, m_util_s.re.mk_concat(m_util_s.re.mk_star(m_util_s.re.mk_full_char(nullptr)),
+                m_util_s.re.mk_concat(m_util_s.re.mk_to_re(m_util_s.str.mk_string(s)),
                 m_util_s.re.mk_star(m_util_s.re.mk_full_char(nullptr)))) ), m);
             add_axiom({mk_literal(e), ~mk_literal(re)});
         } else {
@@ -1510,7 +1510,7 @@ namespace smt::noodler {
         STRACE("str", tout  << "handle_in_re " << mk_pp(e, m) << " " << is_true << std::endl;);
 
         app_ref re_constr(to_app(s), m);
-        /// Check if @p re_constr is a simple variable. If not (it is, e.g., concatenation of string terms), 
+        /// Check if @p re_constr is a simple variable. If not (it is, e.g., concatenation of string terms),
         /// this complex term T is replaced by a fresh variable X. The following axioms are hence added: X = T && X in RE.
         if(re_constr->get_num_args() != 0) {
             app_ref fv(this->m_util_s.mk_skolem(this->m.mk_fresh_var_name(), 0, nullptr, this->m_util_s.mk_string_sort()), m);
@@ -1573,7 +1573,7 @@ namespace smt::noodler {
             refinement = refinement == nullptr ? in_app : m.mk_or(refinement, in_app);
             //STRACE("str", tout << wi.first << " != " << wi.second << '\n';);
         }
-        
+
         if (refinement != nullptr) {
             add_block_axiom(refinement);
         }
@@ -1671,7 +1671,7 @@ namespace smt::noodler {
             expr *const e = ctx.mk_eq_atom(we.first, we.second);
             refinement = refinement == nullptr ? e : m.mk_and(refinement, e);
         }
-        
+
         if(bool_var == nullptr) {
             UNREACHABLE();
         }
@@ -1706,28 +1706,28 @@ namespace smt::noodler {
 
     /**
      * @brief Create fresh string variable
-     * 
-     * @param name Static part of the name (will be concatenated with other parts 
+     *
+     * @param name Static part of the name (will be concatenated with other parts
      *  distinguishing the name)
      * @return expr_ref Fresh string variable
      */
     expr_ref theory_str_noodler::mk_str_var(const std::string& name) {
-        expr_ref var(this->m_util_s.mk_skolem(this->m.mk_fresh_var_name(name.c_str()), 0, 
-            nullptr, this->m_util_s.mk_string_sort()), m); 
+        expr_ref var(this->m_util_s.mk_skolem(this->m.mk_fresh_var_name(name.c_str()), 0,
+            nullptr, this->m_util_s.mk_string_sort()), m);
         return var;
     }
 
     /**
      * @brief Create fresh int variable
-     * 
-     * @param name Static part of the name (will be concatenated with other parts 
+     *
+     * @param name Static part of the name (will be concatenated with other parts
      *  distinguishing the name)
      * @return expr_ref Fresh int variable
      */
     expr_ref theory_str_noodler::mk_int_var(const std::string& name) {
         sort * int_sort = m.mk_sort(m_util_a.get_family_id(), INT_SORT);
-        expr_ref var(this->m_util_s.mk_skolem(this->m.mk_fresh_var_name(name.c_str()), 0, 
-            nullptr, int_sort), m); 
+        expr_ref var(this->m_util_s.mk_skolem(this->m.mk_fresh_var_name(name.c_str()), 0,
+            nullptr, int_sort), m);
         return var;
     }
 
@@ -1736,7 +1736,7 @@ namespace smt::noodler {
     @param ex Z3 expression to be converted to Predicate.
     @return Instance of predicate
     */
-    Predicate theory_str_noodler::conv_eq_pred(const app* ex) { 
+    Predicate theory_str_noodler::conv_eq_pred(const app* ex) {
         const app* eq = ex;
         PredicateType ptype = PredicateType::Equation;
         if(m.is_not(ex)) {
@@ -1753,7 +1753,7 @@ namespace smt::noodler {
         util::collect_terms(to_app(eq->get_arg(0)), this->m_util_s, this->predicate_replace, left);
         util::collect_terms(to_app(eq->get_arg(1)), this->m_util_s, this->predicate_replace, right);
 
-        return Predicate(ptype, std::vector<std::vector<BasicTerm>>{left, right}); 
+        return Predicate(ptype, std::vector<std::vector<BasicTerm>>{left, right});
     }
 
     /**
@@ -1766,6 +1766,6 @@ namespace smt::noodler {
             Predicate inst = this->conv_eq_pred(pred);
             STRACE("str", tout  << "instance conversion " << inst.to_string() << std::endl;);
             res.add_predicate(inst);
-        } 
+        }
     }
 }

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -39,6 +39,7 @@ Eternal glory to Yu-Fang.
 namespace smt::noodler {
 
     class theory_str_noodler : public theory {
+    protected:
 
         int m_scope_level = 0;
         static bool is_over_approximation;
@@ -49,7 +50,7 @@ namespace smt::noodler {
         //ast_manager& m;
 
         StateLen<bool> state_len;
-        AbstractDecisionProcedure* adec_proc;
+        DecisionProcedureDebug* adec_proc; // TODO: Replace with 'AbstractDecisionProcedure*'.
         obj_hashtable<expr> len_vars;
 
         // mapping predicates and function to variables that they substitute to
@@ -131,7 +132,7 @@ namespace smt::noodler {
             delete this->adec_proc;
         }
 
-    private:
+    protected:
         bool is_of_this_theory(expr *e) const;
         bool is_string_sort(expr *e) const;
         bool is_regex_sort(expr *e) const;

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -50,7 +50,6 @@ namespace smt::noodler {
         //ast_manager& m;
 
         StateLen<bool> state_len;
-        DecisionProcedureDebug* adec_proc; // TODO: Replace with 'AbstractDecisionProcedure*'.
         obj_hashtable<expr> len_vars;
 
         // mapping predicates and function to variables that they substitute to
@@ -128,9 +127,7 @@ namespace smt::noodler {
         void add_length(expr* e);
         void enforce_length(expr* n);
 
-        ~theory_str_noodler() {
-            delete this->adec_proc;
-        }
+        ~theory_str_noodler() {}
 
     protected:
         bool is_of_this_theory(expr *e) const;

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -1,5 +1,5 @@
 /*
-The skeleton of this code was obtained by Yu-Fang Chen from https://github.com/guluchen/z3. 
+The skeleton of this code was obtained by Yu-Fang Chen from https://github.com/guluchen/z3.
 Eternal glory to Yu-Fang.
 */
 
@@ -144,7 +144,7 @@ namespace smt::noodler {
         bool_var mk_bool_var(expr *e);
         expr_ref mk_str_var(const std::string& name);
         expr_ref mk_int_var(const std::string& name);
-        
+
         void add_axiom(std::initializer_list<literal> ls);
         void handle_char_at(expr *e);
         void handle_substr(expr *e);

--- a/src/test/noodler/decision-procedure.cpp
+++ b/src/test/noodler/decision-procedure.cpp
@@ -3,10 +3,32 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <mata/re2parser.hh>
+#include <utility>
 #include <smt/theory_str_noodler/decision_procedure.h>
+#include "smt/theory_str_noodler/theory_str_noodler.h"
+#include "ast/reg_decl_plugins.h"
 
 using namespace smt::noodler;
 
+class TheoryStrNoodlerCUT : public theory_str_noodler {
+public:
+    TheoryStrNoodlerCUT(smt::context &ctx, ast_manager &m, const theory_str_params &params)
+            : theory_str_noodler(ctx, m, params) {}
+
+    using theory_str_noodler::m_util_s, theory_str_noodler::m;
+};
+
+class DecisionProcedureCUT : public DecisionProcedure {
+public:
+    DecisionProcedureCUT(const Formula &equalities, AutAssignment init_aut_ass, const std::unordered_set<BasicTerm>& init_length_sensitive_vars, ast_manager& m, seq_util& m_util_s)
+            : DecisionProcedure(equalities, std::move(init_aut_ass), init_length_sensitive_vars, m, m_util_s) {}
+
+    using DecisionProcedure::compute_next_solution;
+    using DecisionProcedure::get_lengths;
+    using DecisionProcedure::get_another_solution;
+    using DecisionProcedure::preprocess;
+    using DecisionProcedure::solution;
+};
 
 // variables have one char names
 Predicate create_equality(std::string left_side, std::string right_side) {
@@ -31,202 +53,215 @@ static std::shared_ptr<Mata::Nfa::Nfa> regex_to_nfa(const std::string& regex) {
     return std::make_shared<Mata::Nfa::Nfa>(aut);
 }
 
-TEST_CASE("unsat-simple", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    // equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a");
-    init_ass[get_var('y')] = regex_to_nfa("a*");
-    init_ass[get_var('z')] = regex_to_nfa("b");
-    init_ass[get_var('u')] = regex_to_nfa("b*");
-    DecisionProcedure proc(equalities, init_ass, { });
-    CHECK(!proc.compute_next_solution());
-}
+TEST_CASE("Decision Procedure", "[noodler]") {
+    memory::initialize(0);
+    smt_params params;
+    ast_manager ast_m;
+    reg_decl_plugins(ast_m);
+    smt::context ctx{ast_m, params };
+    theory_str_params str_params{};
+    TheoryStrNoodlerCUT noodler{ctx, ast_m, str_params };
+    auto& m_util_s{ noodler.m_util_s };
+    auto& m{ noodler.m };
 
-TEST_CASE("sat-simple", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    // equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a*");
-    init_ass[get_var('y')] = regex_to_nfa("a*");
-    init_ass[get_var('z')] = regex_to_nfa("a*");
-    init_ass[get_var('u')] = regex_to_nfa("a*");
-    DecisionProcedure proc(equalities, init_ass, { });
-    CHECK(proc.compute_next_solution());
-}
+    SECTION("unsat-simple", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        // equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a");
+        init_ass[get_var('y')] = regex_to_nfa("a*");
+        init_ass[get_var('z')] = regex_to_nfa("b");
+        init_ass[get_var('u')] = regex_to_nfa("b*");
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s);
+        CHECK(!proc.compute_next_solution());
+    }
 
-TEST_CASE("unsat-FM-example", "[noodler]") {
-    
-    Formula equalities;
-    equalities.add_predicate(create_equality("zyx", "xxz"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a*");
-    init_ass[get_var('y')] = regex_to_nfa("a+b+");
-    init_ass[get_var('z')] = regex_to_nfa("b*");
-    DecisionProcedure proc(equalities, init_ass, { });
-    CHECK(!proc.compute_next_solution());
-}
+    SECTION("sat-simple", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        // equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a*");
+        init_ass[get_var('y')] = regex_to_nfa("a*");
+        init_ass[get_var('z')] = regex_to_nfa("a*");
+        init_ass[get_var('u')] = regex_to_nfa("a*");
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s);
+        CHECK(proc.compute_next_solution());
+    }
 
-TEST_CASE("unsat-simple-length", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    // equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a");
-    init_ass[get_var('y')] = regex_to_nfa("a*");
-    init_ass[get_var('z')] = regex_to_nfa("b");
-    init_ass[get_var('u')] = regex_to_nfa("b*");
-    DecisionProcedure proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") });
-    CHECK(!proc.compute_next_solution());
-}
+    SECTION("unsat-FM-example", "[noodler]") {
 
-TEST_CASE("sat-simple-length", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    // equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a*");
-    init_ass[get_var('y')] = regex_to_nfa("a*");
-    init_ass[get_var('z')] = regex_to_nfa("a*");
-    init_ass[get_var('u')] = regex_to_nfa("a*");
-    DecisionProcedure proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") });
-    CHECK(proc.compute_next_solution());
-    CHECK(proc.compute_next_solution());
-    CHECK(!proc.compute_next_solution());
-}
+        Formula equalities;
+        equalities.add_predicate(create_equality("zyx", "xxz"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a*");
+        init_ass[get_var('y')] = regex_to_nfa("a+b+");
+        init_ass[get_var('z')] = regex_to_nfa("b*");
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s);
+        CHECK(!proc.compute_next_solution());
+    }
 
-TEST_CASE("sat-simple-length-substitution", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    // equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a");
-    init_ass[get_var('y')] = regex_to_nfa("ab*");
-    init_ass[get_var('z')] = regex_to_nfa("ab*");
-    init_ass[get_var('u')] = regex_to_nfa("a*");
-    DecisionProcedure proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") });
+    SECTION("unsat-simple-length", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        // equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a");
+        init_ass[get_var('y')] = regex_to_nfa("a*");
+        init_ass[get_var('z')] = regex_to_nfa("b");
+        init_ass[get_var('u')] = regex_to_nfa("b*");
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s);
+        CHECK(!proc.compute_next_solution());
+    }
 
-    REQUIRE(proc.compute_next_solution());
+    SECTION("sat-simple-length", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        // equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a*");
+        init_ass[get_var('y')] = regex_to_nfa("a*");
+        init_ass[get_var('z')] = regex_to_nfa("a*");
+        init_ass[get_var('u')] = regex_to_nfa("a*");
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s);
+        CHECK(proc.compute_next_solution());
+        CHECK(proc.compute_next_solution());
+        CHECK(!proc.compute_next_solution());
+    }
 
-    REQUIRE(proc.solution.substitution_map.count(get_var('z')) > 0);
-    const auto &z_subst = proc.solution.substitution_map.at(get_var('z'));
-    CHECK(z_subst.size() == 1);
-    const auto &z_tmp_var = z_subst[0];
-    REQUIRE(proc.solution.substitution_map.count(get_var('x')) > 0);
-    REQUIRE(proc.solution.substitution_map.at(get_var('x')).size() == 1);
-    CHECK(z_tmp_var == proc.solution.substitution_map.at(get_var('x'))[0]);
-    REQUIRE(proc.solution.aut_ass.count(z_tmp_var) > 0);
-    CHECK(Mata::Nfa::are_equivalent(*(proc.solution.aut_ass.at(z_subst[0])), *regex_to_nfa("a")));
+    SECTION("sat-simple-length-substitution", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        // equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a");
+        init_ass[get_var('y')] = regex_to_nfa("ab*");
+        init_ass[get_var('z')] = regex_to_nfa("ab*");
+        init_ass[get_var('u')] = regex_to_nfa("a*");
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s);
 
-    CHECK(proc.solution.substitution_map.count(get_var('u')) + proc.solution.substitution_map.count(get_var('y')) == 1);
-    CHECK(proc.solution.aut_ass.count(get_var('u')) + proc.solution.aut_ass.count(get_var('y')) == 1);
+        REQUIRE(proc.compute_next_solution());
 
-    CHECK(!proc.compute_next_solution());
-}
+        REQUIRE(proc.solution.substitution_map.count(get_var('z')) > 0);
+        const auto &z_subst = proc.solution.substitution_map.at(get_var('z'));
+        CHECK(z_subst.size() == 1);
+        const auto &z_tmp_var = z_subst[0];
+        REQUIRE(proc.solution.substitution_map.count(get_var('x')) > 0);
+        REQUIRE(proc.solution.substitution_map.at(get_var('x')).size() == 1);
+        CHECK(z_tmp_var == proc.solution.substitution_map.at(get_var('x'))[0]);
+        REQUIRE(proc.solution.aut_ass.count(z_tmp_var) > 0);
+        CHECK(Mata::Nfa::are_equivalent(*(proc.solution.aut_ass.at(z_subst[0])), *regex_to_nfa("a")));
 
-TEST_CASE("unsat-two-equations", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("(a|b)*");
-    init_ass[get_var('y')] = regex_to_nfa("(a|b)*");
-    init_ass[get_var('z')] = regex_to_nfa("b");
-    init_ass[get_var('u')] = regex_to_nfa("b*");
-    init_ass[get_var('r')] = regex_to_nfa("a*");
-    DecisionProcedure proc(equalities, init_ass, { });
-    CHECK(!proc.compute_next_solution());
-}
+        CHECK(proc.solution.substitution_map.count(get_var('u')) + proc.solution.substitution_map.count(get_var('y')) == 1);
+        CHECK(proc.solution.aut_ass.count(get_var('u')) + proc.solution.aut_ass.count(get_var('y')) == 1);
 
-TEST_CASE("sat-two-equations", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a*");
-    init_ass[get_var('y')] = regex_to_nfa("a*");
-    init_ass[get_var('z')] = regex_to_nfa("a*");
-    init_ass[get_var('u')] = regex_to_nfa("(a|b)*");
-    init_ass[get_var('r')] = regex_to_nfa("aaa");
-    DecisionProcedure proc(equalities, init_ass, { });
-    CHECK(proc.compute_next_solution());
-}
+        CHECK(!proc.compute_next_solution());
+    }
 
-TEST_CASE("unsat-two-equations-length", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("(a|b)*");
-    init_ass[get_var('y')] = regex_to_nfa("(a|b)*");
-    init_ass[get_var('z')] = regex_to_nfa("b");
-    init_ass[get_var('u')] = regex_to_nfa("b*");
-    init_ass[get_var('r')] = regex_to_nfa("a*");
-    DecisionProcedure proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") });
-    CHECK(!proc.compute_next_solution());
-}
+    SECTION("unsat-two-equations", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("(a|b)*");
+        init_ass[get_var('y')] = regex_to_nfa("(a|b)*");
+        init_ass[get_var('z')] = regex_to_nfa("b");
+        init_ass[get_var('u')] = regex_to_nfa("b*");
+        init_ass[get_var('r')] = regex_to_nfa("a*");
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s);
+        CHECK(!proc.compute_next_solution());
+    }
 
-TEST_CASE("sat-two-equations-length", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a*");
-    init_ass[get_var('y')] = regex_to_nfa("ab*");
-    init_ass[get_var('z')] = regex_to_nfa("ab*");
-    init_ass[get_var('u')] = regex_to_nfa("a*");
-    init_ass[get_var('r')] = regex_to_nfa("ab*a");
-    DecisionProcedure proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") });
+    SECTION("sat-two-equations", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a*");
+        init_ass[get_var('y')] = regex_to_nfa("a*");
+        init_ass[get_var('z')] = regex_to_nfa("a*");
+        init_ass[get_var('u')] = regex_to_nfa("(a|b)*");
+        init_ass[get_var('r')] = regex_to_nfa("aaa");
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s);
+        CHECK(proc.compute_next_solution());
+    }
 
-    REQUIRE(proc.compute_next_solution());
+    SECTION("unsat-two-equations-length", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("(a|b)*");
+        init_ass[get_var('y')] = regex_to_nfa("(a|b)*");
+        init_ass[get_var('z')] = regex_to_nfa("b");
+        init_ass[get_var('u')] = regex_to_nfa("b*");
+        init_ass[get_var('r')] = regex_to_nfa("a*");
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s);
+        CHECK(!proc.compute_next_solution());
+    }
 
-    AutAssignment squashed_aut_ass = proc.solution.flatten_substition_map();
-    CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('x')), *regex_to_nfa("a")));
-    CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('z')), *regex_to_nfa("a")));
-    
-    CHECK(!proc.compute_next_solution());
-}
+    SECTION("sat-two-equations-length", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a*");
+        init_ass[get_var('y')] = regex_to_nfa("ab*");
+        init_ass[get_var('z')] = regex_to_nfa("ab*");
+        init_ass[get_var('u')] = regex_to_nfa("a*");
+        init_ass[get_var('r')] = regex_to_nfa("ab*a");
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s);
 
-TEST_CASE("sat-two-equations-length2", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("xy", "zu"));
-    equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a*");
-    init_ass[get_var('y')] = regex_to_nfa("ab*");
-    init_ass[get_var('z')] = regex_to_nfa("ab*");
-    init_ass[get_var('u')] = regex_to_nfa("a*");
-    init_ass[get_var('r')] = regex_to_nfa("ab*a");
-    DecisionProcedure proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") , BasicTerm(BasicTermType::Variable, "r") });
+        REQUIRE(proc.compute_next_solution());
 
-    REQUIRE(proc.compute_next_solution());
+        AutAssignment squashed_aut_ass = proc.solution.flatten_substition_map();
+        CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('x')), *regex_to_nfa("a")));
+        CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('z')), *regex_to_nfa("a")));
 
-    AutAssignment squashed_aut_ass = proc.solution.flatten_substition_map();
-    CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('x')), *regex_to_nfa("a")));
-    CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('z')), *regex_to_nfa("a")));
-    CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('r')), *regex_to_nfa("aa")));
+        CHECK(!proc.compute_next_solution());
+    }
 
-    CHECK(!proc.compute_next_solution());
-}
+    SECTION("sat-two-equations-length2", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("xy", "zu"));
+        equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a*");
+        init_ass[get_var('y')] = regex_to_nfa("ab*");
+        init_ass[get_var('z')] = regex_to_nfa("ab*");
+        init_ass[get_var('u')] = regex_to_nfa("a*");
+        init_ass[get_var('r')] = regex_to_nfa("ab*a");
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") , BasicTerm(BasicTermType::Variable, "r") }, m, m_util_s);
 
-TEST_CASE("unsat-simple-non-chain-free", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("x", "xx"));
-    // equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("aa?b*");
-    DecisionProcedure proc(equalities, init_ass, { });
-    CHECK(!proc.compute_next_solution());
-}
+        REQUIRE(proc.compute_next_solution());
 
-TEST_CASE("sat-simple-non-chain-free", "[nooodler]") {
-    Formula equalities;
-    equalities.add_predicate(create_equality("x", "xx"));
-    // equalities.add_predicate(create_equality("yx", "r"));
-    AutAssignment init_ass;
-    init_ass[get_var('x')] = regex_to_nfa("a*b*");
-    DecisionProcedure proc(equalities, init_ass, { });
-    CHECK(proc.compute_next_solution());
+        AutAssignment squashed_aut_ass = proc.solution.flatten_substition_map();
+        CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('x')), *regex_to_nfa("a")));
+        CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('z')), *regex_to_nfa("a")));
+        CHECK(Mata::Nfa::are_equivalent(*squashed_aut_ass.at(get_var('r')), *regex_to_nfa("aa")));
+
+        CHECK(!proc.compute_next_solution());
+    }
+
+    SECTION("unsat-simple-non-chain-free", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("x", "xx"));
+        // equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("aa?b*");
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s);
+        CHECK(!proc.compute_next_solution());
+    }
+
+    SECTION("sat-simple-non-chain-free", "[nooodler]") {
+        Formula equalities;
+        equalities.add_predicate(create_equality("x", "xx"));
+        // equalities.add_predicate(create_equality("yx", "r"));
+        AutAssignment init_ass;
+        init_ass[get_var('x')] = regex_to_nfa("a*b*");
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s);
+        CHECK(proc.compute_next_solution());
+    }
+    memory::finalize();
 }

--- a/src/test/noodler/decision-procedure.cpp
+++ b/src/test/noodler/decision-procedure.cpp
@@ -20,12 +20,13 @@ public:
 
 class DecisionProcedureCUT : public DecisionProcedure {
 public:
-    DecisionProcedureCUT(const Formula &equalities, AutAssignment init_aut_ass, const std::unordered_set<BasicTerm>& init_length_sensitive_vars, ast_manager& m, seq_util& m_util_s)
-            : DecisionProcedure(equalities, std::move(init_aut_ass), init_length_sensitive_vars, m, m_util_s) {}
+    DecisionProcedureCUT(const Formula &equalities, AutAssignment init_aut_ass,
+                         const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+                         ast_manager& m, seq_util& m_util_s
+    ) : DecisionProcedure(equalities, std::move(init_aut_ass), init_length_sensitive_vars, m, m_util_s) {}
 
     using DecisionProcedure::compute_next_solution;
     using DecisionProcedure::get_lengths;
-    using DecisionProcedure::get_another_solution;
     using DecisionProcedure::preprocess;
     using DecisionProcedure::solution;
 };


### PR DESCRIPTION
This PR stabilizes interface for `AbstractDecisionProcedure` and `DecisionProcedure`. Furthermore, the PR modifies `theory_str_noodler::final_check_eh()` to call the new interface.

Several functions in `DecisionProcedure` remain unimplemented. That will be the content of next PRs.