### PR TITLE
Remove forgotten old code

### DIFF
--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -374,8 +374,6 @@ namespace smt::noodler::util {
                        std::vector<BasicTerm>& terms) {
 
         if(m_util_s.str.is_string(ex)) {
-            std::string lit = ex->get_parameter(0).get_zstring().encode();
-            terms.emplace_back(BasicTermType::Literal, lit);
             terms.emplace_back(BasicTermType::Literal, util::conv_to_regex_hex(ex, m_util_s, m, {}));
             return;
         }


### PR DESCRIPTION
This PR removes old code which magically appeared in the source file again after merging the previous commit which was supposed to remove it. Here is to hoping such foul tricks will not be pulled any more.