### PR TITLE
Check whether expr is variable

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -768,6 +768,14 @@ namespace smt::noodler {
         return is_app(e) && to_app(e)->get_decl()->get_arity() == 0;
     }
 
+    bool theory_str_noodler::is_str_variable(const expr* expression) const {
+        return util::is_str_variable(expression, m_util_s);
+    }
+
+    bool theory_str_noodler::is_variable(const expr* expression) const {
+        return util::is_variable(expression, m_util_s);
+    }
+
     expr_ref theory_str_noodler::mk_sub(expr *a, expr *b) {
         ast_manager &m = get_manager();
 

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -136,6 +136,26 @@ namespace smt::noodler {
         bool is_string_sort(expr *e) const;
         bool is_regex_sort(expr *e) const;
         bool is_const_fun(expr *e) const;
+
+        /**
+         * Check whether an @p expression is a string variable.
+         *
+         * Function checks only the top-level expression and is not recursive.
+         * Regex variables do not count as string variables.
+         * @param expression Expression to check.
+         * @return True if @p expression is a variable, false otherwise.
+         */
+        bool is_str_variable(const expr* expression) const;
+
+        /**
+         * Check whether an @p expression is any kind of variable (string, regex, integer).
+         *
+         * Function checks only the top-level expression and is not recursive.
+         * @param expression Expression to check.
+         * @return True if @p expression is a variable, false otherwise.
+         */
+        bool is_variable(const expr* expression) const;
+
         expr_ref mk_sub(expr *a, expr *b);
         zstring print_word_term(expr * a) const;
 

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -22,7 +22,7 @@ namespace smt::noodler::util {
             return;
         }
 
-        if(is_app(ex) && to_app(ex)->get_num_args() == 0) { // Skip variables.
+        if(util::is_variable(ex, m_util_s)) { // Skip variables.
             return;
         }
 
@@ -101,7 +101,7 @@ namespace smt::noodler::util {
             SASSERT(is_app(child));
             extract_symbols(to_app(child), m_util_s, m, alphabet);
             return;
-        } else if(is_app(ex_app) && to_app(ex_app)->get_num_args() == 0) { // Handle variable.
+        } else if(is_variable(ex_app, m_util_s)) { // Handle variable.
             assert(false && "is_variable(ex_app)");
         }
 
@@ -118,7 +118,7 @@ namespace smt::noodler::util {
             return;
         }
 
-        if(m_util_s.is_string(ex->get_sort()) && is_app(ex) && to_app(ex)->get_num_args() == 0) {
+        if(is_str_variable(ex, m_util_s)) {
             res.insert(ex);
             return;
         }
@@ -138,7 +138,7 @@ namespace smt::noodler::util {
             return;
         }
 
-        if(is_app(ex) && to_app(ex)->get_num_args() == 0) {
+        if(is_variable(ex, m_util_s)) {
             res.insert(std::to_string(to_app(ex)->get_name()));
             return;
         }
@@ -151,6 +151,24 @@ namespace smt::noodler::util {
             app *arg = to_app(ex_app->get_arg(i));
             get_variable_names(arg, m_util_s, m, res);
         }
+    }
+
+    bool is_variable(const expr* expression, const seq_util& m_util_s) {
+        // TODO: When we are able to detect other kinds of variables, add their checks here.
+        return is_str_variable(expression, m_util_s);
+    }
+
+    bool is_str_variable(const expr* expression, const seq_util& m_util_s) {
+        if(m_util_s.str.is_string(expression)) { // Filter away string literals first.
+            return false;
+        }
+
+        if (m_util_s.is_string(expression->get_sort()) &&
+            is_app(expression) && to_app(expression)->get_num_args() == 0) {
+            return true;
+        }
+
+        return false;
     }
 
     std::set<uint32_t> get_dummy_symbols(const vector<expr_pair>& disequations, std::set<uint32_t>& symbols_to_append_to) {
@@ -350,7 +368,7 @@ namespace smt::noodler::util {
                 // std::setfill('0') << std::setw(2) <<
             }
             regex = convert_stream.str();
-        } else if(is_app(expr) && to_app(expr)->get_num_args() == 0) { // Handle variable.
+        } else if(is_variable(expr, m_util_s)) { // Handle variable.
             assert(false && "is_variable(expr)");
         }
 
@@ -378,7 +396,7 @@ namespace smt::noodler::util {
             return;
         }
 
-        if(is_app(ex) && to_app(ex)->get_num_args() == 0) {
+        if(is_variable(ex, m_util_s)) {
             std::string var = ex->get_decl()->get_name().str();
             terms.emplace_back(BasicTermType::Variable, var);
             return;

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -39,6 +39,25 @@ namespace smt::noodler::util {
     void get_str_variables(expr* ex, const seq_util& m_util_s, const ast_manager& m, obj_hashtable<expr>& res);
 
     /**
+     * Check whether an @p expression is a string variable.
+     *
+     * Function checks only the top-level expression and is not recursive.
+     * Regex variables do not count as string variables.
+     * @param expression Expression to check.
+     * @return True if @p expression is a variable, false otherwise.
+     */
+    bool is_str_variable(const expr* expression, const seq_util& m_util_s);
+
+    /**
+     * Check whether an @p expression is any kind of variable (string, regex, integer).
+     *
+     * Function checks only the top-level expression and is not recursive.
+     * @param expression Expression to check.
+     * @return True if @p expression is a variable, false otherwise.
+     */
+    bool is_variable(const expr* expression, const seq_util& m_util_s);
+
+    /**
      * Get variable names from a given expression @p ex. Append to the output parameter @p res.
      * @param[in] ex Expression to be checked for variables.
      * @param[in] m_util_s Seq util for AST.

--- a/src/test/noodler/test_utils.h
+++ b/src/test/noodler/test_utils.h
@@ -20,6 +20,7 @@ public:
             : theory_str_noodler(ctx, m, params) {}
 
     using theory_str_noodler::m_util_s, theory_str_noodler::m, theory_str_noodler::m_util_a;
+    using theory_str_noodler::mk_str_var, theory_str_noodler::mk_int_var, theory_str_noodler::mk_literal;
 };
 
 class DecisionProcedureCUT : public DecisionProcedure {

--- a/src/test/noodler/util.cc
+++ b/src/test/noodler/util.cc
@@ -21,6 +21,7 @@ TEST_CASE("theory_str_noodler::util::conv_to_regex_hex()", "[noodler]") {
     std::set<uint32_t> alphabet{ '\x78', '\x79', '\x7A' };
     auto& m_util_s{ noodler.m_util_s };
     auto& m{ noodler.m };
+    auto& m_util_a{ noodler.m_util_a };
     auto default_sort{ ast_m.mk_sort(symbol{ "RegEx" }, sort_info{ noodler.get_family_id(), 1, sort_size(0), 0, nullptr }) };
 
     SECTION("util::conv_to_regex_hex()") {
@@ -80,6 +81,7 @@ TEST_CASE("theory_str_noodler::util") {
     TheoryStrNoodlerCUT noodler{ctx, ast_m, str_params };
     std::set<uint32_t> alphabet{ '\x78', '\x79', '\x7A' };
     auto& m_util_s{ noodler.m_util_s };
+    auto& m_util_a{ noodler.m_util_a };
     auto& m{ noodler.m };
     auto default_sort{ ast_m.mk_sort(symbol{ "RegEx" }, sort_info{ noodler.get_family_id(), 1, sort_size(0), 0, nullptr }) };
 
@@ -112,5 +114,16 @@ TEST_CASE("theory_str_noodler::util") {
 
         util::extract_symbols(expr_concat, m_util_s, m, alphabet);
         CHECK(alphabet == std::set<uint32_t>{ '\x02', '\x45', '\x77', '\x78', '\x79', '\x7a' });
+    }
+
+    SECTION("util::is_str_variable()") {
+        expr_ref str_variable{ noodler.mk_str_var(symbol("var1")), m };
+        CHECK(util::is_str_variable(str_variable, m_util_s));
+        expr_ref str_literal{m_util_s.str.mk_string("var1"), m };
+        CHECK(!util::is_str_variable(str_literal, m_util_s));
+        expr_ref regex{ m_util_s.re.mk_to_re(m_util_s.str.mk_string(".*regex.*")), m };
+        CHECK(!util::is_str_variable(regex, m_util_s));
+        expr_ref int_literal{ m_util_a.mk_int(1), m };
+        CHECK(!util::is_str_variable(int_literal, m_util_s));
     }
 }


### PR DESCRIPTION
This PR implements functions to check whether an expression is a variable. As of now, we can safely determine only whether the expression is a string variable. The PR prepares for the future when we would want to check for other kinds of variables as well.