### PR TITLE
Convert string literals to fresh string literals

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -195,13 +195,25 @@ namespace smt::noodler {
         AutAssignment init_aut_ass;
 
         /**
-         * Convert all string literals in @c formula to fresh variables with automata in automata assignment.
+         * @brief Convert all string literals in @c formula to fresh string literals with automata in automata assignment.
          *
-         * All string literals are converted to fresh variables with assigned automata equal to the string literal
+         * All string literals are converted to fresh string literals with assigned automata equal to the string literal
          *  expression.
-         * We get a new fresh variable for each separate string literal, even if there are multiple same string literals.
+         * We get a new fresh literal for each separate string literal, but multiple occurrences of the same string
+         *  literal have the same name.
          */
-        void conv_str_lits_to_fresh_vars();
+        void conv_str_lits_to_fresh_lits();
+
+        /**
+         * Convert string literals on a single side to fresh string literals with the same literals having the same name.
+         * @param side Side for which to convert literals in place.
+         * @param fresh_lits_counter Counter for unique trailing numbers where to start for creating unique names of
+         *  fresh string literals.
+         * @param converted_str_literals Map of found string literals to their fresh names.
+         */
+        void conv_str_lits_to_fresh_lits_for_side(std::vector<BasicTerm>& side, size_t& fresh_lits_counter,
+                                                  std::map<zstring, std::string>& converted_str_literals);
+
 
         expr_ref mk_len_aut_constr(const expr_ref& var, int v1, int v2);
         expr_ref mk_len_aut(const expr_ref& var, std::set<std::pair<int, int>>& aut_constr);

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -272,7 +272,7 @@ namespace smt::noodler {
             auto plus_chain = [&](const std::vector<BasicTerm>& side) {
                 std::vector<LenNode*> ops;
                 if(side.size() == 0) {
-                    return new LenNode(LenFormulaType::LEAF, BasicTerm(BasicTermType::Literal, "0"), {});
+                    return new LenNode(LenFormulaType::LEAF, BasicTerm(BasicTermType::Length, "0"), {});
                 }
                 if(side.size() == 1) {
                     return new LenNode(LenFormulaType::LEAF, side[0], {});

--- a/src/smt/theory_str_noodler/inclusion_graph.cc
+++ b/src/smt/theory_str_noodler/inclusion_graph.cc
@@ -161,7 +161,6 @@ Graph smt::noodler::Graph::create_simplified_splitting_graph(const Formula& form
                 } else {
                     // In different equation.
                 }
-
             } else {
                 // Have same var and sides are not equal, automatically add a new edge.
             }
@@ -199,7 +198,7 @@ Graph smt::noodler::Graph::create_inclusion_graph(Graph& simplified_splitting_gr
                 inclusion_graph.nodes_not_on_cycle.insert(node); // the inserted node cannot be on the cycle, because it is either initial or all nodes leading to it were not on cycle
                 if (simplified_splitting_graph.initial_nodes.count(node) > 0) {
                     inclusion_graph.initial_nodes.insert(node);
-                } 
+                }
 
                 out_node_order.push_back(node);
 

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -221,7 +221,7 @@ namespace smt::noodler::util {
     static expr_ref len_to_expr(const LenNode * node, std::map<BasicTerm, expr_ref>& variable_map, ast_manager &m, seq_util& m_util_s, arith_util& m_util_a) {
         switch(node->type) {
         case LenFormulaType::LEAF:
-            if(node->atom_val.is_literal())
+            if(node->atom_val.get_type() == BasicTermType::Length)
                 return expr_ref(m_util_a.mk_int(std::stoi(node->atom_val.get_name().encode())), m);
             else {
                 auto it = variable_map.find(node->atom_val);


### PR DESCRIPTION
This PR converts string literals to fresh string literals, where the same string literals have the same name and the corresponding automaton in the `aut_ass`.

This PR already incorporate the changes introduced by #31. And the failing benchmarks appear to be passing again. If we merge this PR, #31 can be closed without the need to resolve the conflicts.