### PR TITLE
fix: Expr int solver

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -440,7 +440,6 @@ namespace smt::noodler {
                     if (term.is_literal()) { // Handle string literal.
                         BasicTerm fresh_variable{ BasicTermType::Variable, name_prefix + std::to_string(counter)};
                         ++counter;
-                        STRACE("str", tout << term.get_name() << " = " << fresh_variable.get_name() << "\n");
                         Mata::Nfa::Nfa nfa{ util::create_word_nfa(term.get_name()) };
                         init_aut_ass.emplace(fresh_variable, std::make_shared<Mata::Nfa::Nfa>(std::move(nfa)));
                         term = fresh_variable;

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -340,6 +340,8 @@ namespace smt::noodler {
             lengths = this->m.mk_and(lengths, prep_formula);
         }
 
+        STRACE("str", tout << mk_pp(lengths, this->m) << "\n");
+
         return lengths;
     }
 
@@ -438,6 +440,7 @@ namespace smt::noodler {
                     if (term.is_literal()) { // Handle string literal.
                         BasicTerm fresh_variable{ BasicTermType::Variable, name_prefix + std::to_string(counter)};
                         ++counter;
+                        STRACE("str", tout << term.get_name() << " = " << fresh_variable.get_name() << "\n");
                         Mata::Nfa::Nfa nfa{ util::create_word_nfa(term.get_name()) };
                         init_aut_ass.emplace(fresh_variable, std::make_shared<Mata::Nfa::Nfa>(std::move(nfa)));
                         term = fresh_variable;

--- a/src/smt/theory_str_noodler/expr_solver.h
+++ b/src/smt/theory_str_noodler/expr_solver.h
@@ -95,7 +95,8 @@ namespace smt::noodler {
 
         void assert_expr(expr * e) {
             if(!unsat_core){
-                m_kernel.assert_expr(e);
+                erv.push_back(e);
+                // m_kernel.assert_expr(e);
 
             } else {
                 erv.push_back(e);

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -168,6 +168,8 @@ namespace smt::noodler {
                     ret.insert(pr.first);
                 if(pred_set.size() == 1 && is_init(*pred_set.begin()))
                     ret.insert(pr.first);
+                if(pred_set.size() == 1 && this->succ.at(*pred_set.begin()).size() > 1)
+                    ret.insert(pr.first);
             }
             return ret;
         }


### PR DESCRIPTION
This PR fixes a bug in `slog_stranger_48_sink.smt2`. Here the INT solver wrongly said UNSAT, although it was SAT. To be honest, don't know exactly why it works now and what was the original problem.