### PR TITLE
Fix regular constraints automata creation

### DIFF
--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -143,8 +143,8 @@ namespace smt::noodler::util {
      * @param[in] make_complement Whether to make complement of the passed @p expr instead.
      * @return The resulting regex.
      */
-    [[nodiscard]] Mata::Nfa::Nfa conv_to_nfa_hex(const app *expr, const seq_util& m_util_s, const ast_manager& m,
-                                              const std::set<uint32_t>& alphabet, bool make_complement = false);
+    [[nodiscard]] Mata::Nfa::Nfa conv_to_nfa(const app *expr, const seq_util& m_util_s, const ast_manager& m,
+                                             const std::set<uint32_t>& alphabet, bool make_complement = false);
 
     /**
      * Create NFA accepting a word in Z3 zstring representation.


### PR DESCRIPTION
This PR fixes creation of a combination of regular constraints for a single variable with creation of an intersection of the underlying NFAs for each regular constraint.

Furthermore, seeing as we no longer use hexa values for RE2Parser and directly use the Z3 `uint32_t` values instead, I changed the function name to reflect that.