### PR TITLE
Print inclusion graph to DOT format

### DIFF
--- a/src/smt/theory_str_noodler/inclusion_graph.cc
+++ b/src/smt/theory_str_noodler/inclusion_graph.cc
@@ -15,6 +15,50 @@ namespace {
         }
         return false;
     }
+
+    /**
+     * Convert graph node into string representation.
+     * @param node Node to convert.
+     * @return String representation of @p node.
+     */
+    std::string conv_node_to_string(const std::shared_ptr<GraphNode>& node) {
+        auto& predicate{ node->get_predicate() };
+        std::string result{};
+        switch (predicate.get_type()) {
+            case PredicateType::Equation:
+            case PredicateType::Inequation: {
+                std::string left_side{};
+                for (auto& item : predicate.get_left_side()) {
+                    if (!left_side.empty()) { left_side += " "; }
+                    left_side += item.to_string();
+                }
+
+                std::string right_side{};
+                for (auto& item : predicate.get_right_side()) {
+                    if (!right_side.empty()) { right_side += " "; }
+                    right_side += item.to_string();
+                }
+                result = left_side;
+                if (predicate.get_type() == PredicateType::Inequation) {
+                    result += " !";
+                } else {
+                    result += " ";
+                }
+                result += "<= ";
+                result += right_side;
+                break;
+            }
+            case PredicateType::Default: {
+                result = "default predicate type";
+                break;
+            }
+            case PredicateType::Contains: {
+                result = "contains predicate type";
+                break;
+            }
+        }
+        return result;
+    }
 } // Anonymous namespace.
 
 const smt::noodler::Graph::Nodes smt::noodler::Graph::empty_nodes = smt::noodler::Graph::Nodes();
@@ -228,4 +272,16 @@ Graph smt::noodler::Graph::create_inclusion_graph(Graph& simplified_splitting_gr
     inclusion_graph.add_inclusion_graph_edges();
 
     return inclusion_graph;
+}
+
+void Graph::print_to_dot(std::ostream &output_stream) const {
+    output_stream << "digraph inclusionGraph {\nnode [shape=none];\n";
+    for (const auto& edge : edges) {
+        output_stream << "\"" << conv_node_to_string(edge.first) << "\" -> {";
+        for (const auto& target : edge.second) {
+            output_stream << "\"" << conv_node_to_string(target) << "\" ";
+        }
+        output_stream << "} [label=\"\"]\n";
+    }
+    output_stream << "}" << std::endl;
 }

--- a/src/smt/theory_str_noodler/inclusion_graph.h
+++ b/src/smt/theory_str_noodler/inclusion_graph.h
@@ -173,7 +173,6 @@ namespace smt::noodler {
             return new_node;
         }
 
-
         /**
          * @brief adds node with predicate to graph (even if a node with such predicate exists in graph)
          *
@@ -211,6 +210,12 @@ namespace smt::noodler {
         static Graph create_inclusion_graph(const Formula& formula, std::deque<std::shared_ptr<GraphNode>> &out_node_order);
         static Graph create_simplified_splitting_graph(const Formula& formula);
         static Graph create_inclusion_graph(Graph& simplified_splitting_graph, std::deque<std::shared_ptr<GraphNode>> &out_node_order);
+
+        /**
+         * Print the inclusion graph in a DOT format.
+         * @param output_stream Stream to print the graph to.
+         */
+        void print_to_dot(std::ostream &output_stream) const;
     }; // Class Graph.
 }
 

--- a/src/test/noodler/inclusion-graph-node.cc
+++ b/src/test/noodler/inclusion-graph-node.cc
@@ -337,3 +337,26 @@ TEST_CASE("Splitting graph", "[noodler]") {
         CHECK(graph.get_edges().empty());
     }
 }
+
+TEST_CASE("print_to_dot()") {
+    Graph graph;
+    Formula formula;
+
+    BasicTerm u{ BasicTermType::Variable, "u" };
+    BasicTerm v{ BasicTermType::Variable, "v" };
+    BasicTerm x{ BasicTermType::Variable, "x" };
+    BasicTerm y{ BasicTermType::Variable, "y" };
+    BasicTerm z{ BasicTermType::Variable, "z" };
+
+    Predicate predicate{ PredicateType::Equation, { { u }, { z } } };
+    Predicate predicate2{ PredicateType::Equation, { { v }, { u } } };
+    Predicate predicate3{ PredicateType::Equation, { { x }, { u, v, x } } };
+
+    formula.add_predicate(predicate);
+    formula.add_predicate(predicate2);
+    formula.add_predicate(predicate3);
+    graph = Graph::create_inclusion_graph(formula);
+    std::stringstream stream;
+    graph.print_to_dot(stream);
+    CHECK(!stream.str().empty());
+}


### PR DESCRIPTION
This PR implements a basic method of inclusion graph to print the graph to DOT format.

Fixes #30. 