### PR TITLE
Create OnTheFlyAlphabet for NFAs in AutAssigment

### DIFF
--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -45,7 +45,7 @@ namespace smt::noodler {
         };
 
         Mata::Nfa::Nfa sigma_star_automaton() const {
-            Mata::Nfa::Nfa nfa(1);
+            Mata::Nfa::Nfa nfa{};
             nfa.initial = {0};
             nfa.final = {0};
             for (const Mata::Symbol& symb : this->alphabet) {
@@ -55,7 +55,7 @@ namespace smt::noodler {
         }
 
         Mata::Nfa::Nfa sigma_automaton() const {
-            Mata::Nfa::Nfa nfa(2);
+            Mata::Nfa::Nfa nfa{};
             nfa.initial = {0};
             nfa.final = {1};
             for (const Mata::Symbol& symb : this->alphabet) {
@@ -102,7 +102,7 @@ namespace smt::noodler {
 
         /**
          * @brief Check if all automata in the map have non-empty language.
-         * 
+         *
          * @return true All have non-empty language
          * @return false There is at least one NFA with the empty language
          */

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -266,13 +266,13 @@ namespace smt::noodler::util {
         }
 
         // Assign sigma start automata for all yet unassigned variables.
-        Mata::OnTheFlyAlphabet mata_alphabet{};
+        Mata::OnTheFlyAlphabet* mata_alphabet{ new Mata::OnTheFlyAlphabet{} };
         std::string hex_symbol_string;
         for (const uint32_t symbol : noodler_alphabet) {
-            mata_alphabet.add_new_symbol(std::to_string(symbol), symbol);
+            mata_alphabet->add_new_symbol(std::to_string(symbol), symbol);
         }
 
-        const Nfa nfa_sigma_star{ Mata::Nfa::create_sigma_star_nfa(&mata_alphabet) };
+        const Nfa nfa_sigma_star{ Mata::Nfa::create_sigma_star_nfa(mata_alphabet) };
         for (const auto& variable : variables_in_formula) {
             if (variables_with_regex.find(variable.get_name().encode()) == variables_with_regex.end()) {
                 assert(aut_assignment.find(variable) == aut_assignment.end());
@@ -529,7 +529,12 @@ namespace smt::noodler::util {
     }
 
     Nfa create_word_nfa(const zstring& word) {
-        Nfa nfa{};
+        const size_t word_length{ word.length() };
+        Mata::OnTheFlyAlphabet* mata_alphabet{ new Mata::OnTheFlyAlphabet{} };
+        for (size_t i{ 0 }; i < word_length; ++i) {
+            mata_alphabet->try_add_new_symbol(std::to_string(word[i]), word[i]);
+        }
+        Mata::Nfa::Nfa nfa{ word_length, { 0 }, { word_length }, mata_alphabet };
         nfa.initial.add(0);
         size_t state{ 0 };
         for (; state < word.length(); ++state) {


### PR DESCRIPTION
This PR modifies the current `create_word_nfa()` function to create an explicit `OnTheFlyAlphabet`.

Fixes #40.