### PR TITLE
Fix dummy symbols creation

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -757,9 +757,6 @@ namespace smt::noodler {
         )};
 
         // Add dummy symbols for all disequations.
-        if(symbols_in_formula.size() + new_symbs <= 1) { // alphabet should have at least 2 symbols
-            new_symbs++;
-        }
         std::set<uint32_t> dummy_symbols{ util::get_dummy_symbols(std::max(new_symbs, size_t(3)), symbols_in_formula) };
         // Create automata assignment for the formula.
         AutAssignment aut_assignment{util::create_aut_assignment_for_formula(

--- a/src/test/noodler/util.cc
+++ b/src/test/noodler/util.cc
@@ -99,7 +99,7 @@ TEST_CASE("theory_str_noodler::util") {
         ));
 
         alphabet.insert({ '\x45', '\x02', '\x03', '\x00' });
-        std::set<uint32_t> dummy_symbols{ util::get_dummy_symbols(disequations, alphabet) };
+        std::set<uint32_t> dummy_symbols{ util::get_dummy_symbols(disequations.size(), alphabet) };
         CHECK(dummy_symbols == std::set<uint32_t>{ '\x01', '\x04' });
         CHECK(alphabet == std::set<uint32_t>{ '\x00', '\x01', '\x02', '\x03', '\x04', '\x45', '\x78', '\x79', '\x7a' });
     }


### PR DESCRIPTION
This PR removes a useless increment of `new_symbs`, because it has no effect on program execution due to us creating dummy symbols from `std::max(new_symbs, 3)` one line below. Moreover, the PR fixes tests to reflect the changes in `util::get_dummy_symbols`.` 