### PR TITLE
Fixing decision procedure + better commented code

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -53,6 +53,12 @@ namespace smt::noodler {
         for (const auto &subst_map_pair : substitution_map) {
             flatten_var(subst_map_pair.first);
         }
+        STRACE("str-nfa",
+            tout << "Flattened substitution map:" << std::endl;
+            for (const auto &var_aut : result) {
+                tout << "Var " << var_aut.first.get_name() << std::endl;
+                var_aut.second->print_to_DOT(tout);
+            });
         return result;
     }
 
@@ -68,53 +74,69 @@ namespace smt::noodler {
     }
 
     bool DecisionProcedure::compute_next_solution() {
-
+        // iteratively select next state of solving that can lead to solution and
+        // process one of the unprocessed nodes (or possibly find solution)
         while (!worklist.empty()) {
             SolvingState element_to_process = std::move(worklist.front());
             worklist.pop_front();
 
             if (element_to_process.nodes_to_process.empty()) {
-                // TODO do some arithmetic shit?
+                // we found another solution, element_to_process contain the automata
+                // assignment and variable substition that satisfy the original
+                // inclusion graph
                 solution = std::move(element_to_process);
                 return true;
             }
 
+            // we will now process one inclusion from the inclusion graph which is at front
+            // i.e. we will update automata assignments and substitutions so that this inclusion is fulfilled
             std::shared_ptr<GraphNode> node_to_process = element_to_process.nodes_to_process.front();
-            assert(node_to_process != nullptr);
             element_to_process.nodes_to_process.pop_front();
+            assert(node_to_process != nullptr);
 
             STRACE("str", tout << "Processing node with inclusion " << node_to_process->get_predicate() <<std::endl;);
-            STRACE("str", tout << "Length variables are:"; for(auto const &var : node_to_process->get_predicate().get_vars()) {if (element_to_process.length_sensitive_vars.count(var)) {tout << " " << var.to_string() <<std::endl;}});
+            STRACE("str", tout << "Length variables are:"; 
+                          for(auto const &var : node_to_process->get_predicate().get_vars()) {
+                              if (element_to_process.length_sensitive_vars.count(var)) {
+                                  tout << " " << var.to_string();
+                              }
+                          }
+                          tout << std::endl;
+                          );
 
             const auto &left_side_vars = node_to_process->get_predicate().get_left_side();
             const auto &right_side_vars = node_to_process->get_predicate().get_right_side();
 
-            bool is_there_length_on_right = false;
-            for (auto const &right_var : right_side_vars) {
-                if (element_to_process.length_sensitive_vars.count(right_var) > 0) {
-                    is_there_length_on_right = true;
-                    break;
-                }
-            }
-
+            // this will decide whether we will continue in our search by DFS or by BFS
             bool is_node_to_process_on_cycle = element_to_process.inclusion_graph->is_on_cycle(node_to_process);
-            
-            // as kinda opmtimalization step, we do "noodlification" for empty sides separately (i.e. sides that represent empty string)
-            // this is because it is simpler, we would get only one noodle so we just need to check
-            // that the non-empty side actually contain empty string and replace the vars on that side by epsilon
+
+
+            /********************************************************************************************************/
+            /****************************************** One side is empty *******************************************/
+            /********************************************************************************************************/
+            // As kinda opmtimalization step, we do "noodlification" for empty sides separately (i.e. sides that
+            // represent empty string). This is because it is simpler, we would get only one noodle so we just need to
+            // check that the non-empty side actually contains empty string and replace the vars on that side by epsilon.
             if (right_side_vars.empty() || left_side_vars.empty()) {
                 std::unordered_map<BasicTerm, std::vector<BasicTerm>> substitution_map;
-                auto const &non_empty_side_vars = right_side_vars.empty() ? node_to_process->get_predicate().get_left_set() : node_to_process->get_predicate().get_right_set();
+                auto const non_empty_side_vars = right_side_vars.empty() ? 
+                                                        node_to_process->get_predicate().get_left_set()
+                                                      : node_to_process->get_predicate().get_right_set();
                 bool non_empty_side_contains_empty_word = true;
                 for (const auto &var : non_empty_side_vars) {
                     if (Mata::Nfa::is_in_lang(*element_to_process.aut_ass.at(var), {{}, {}})) {
-                        if (!right_side_vars.empty() || element_to_process.length_sensitive_vars.count(var) > 0) {
+                        // var contains empty word, we substitute it with only empty word, but only if...
+                        if (right_side_vars.empty() // ...non-empty side is the left side (var is from left) or...
+                               || element_to_process.length_sensitive_vars.count(var) > 0 // ...var is length-aware
+                         ) {
                             assert(substitution_map.count(var) == 0 && element_to_process.aut_ass.count(var) > 0);
-                            // we prepare substitution for all vars on the left or only the length vars on the right (as non-length vars are probably not needed? TODO: would it make sense to update non-length vars too?)
+                            // we prepare substitution for all vars on the left or only the length vars on the right
+                            // (as non-length vars are probably not needed? TODO: would it make sense to update non-length vars too?)
                             substitution_map[var] = {};
                             element_to_process.aut_ass.erase(var);
                         }
                     } else {
+                        // var does not contain empty word => whole non-empty side cannot contain empty word
                         non_empty_side_contains_empty_word = false;
                         break;
                     }
@@ -127,8 +149,9 @@ namespace smt::noodler {
 
                 // TODO: all this following shit is done also during normal noodlification, I need to split it to some better defined functions
 
-                // we might remove some variables from the left side
-                // so we need to add all nodes whose variable assignments are going to change on the right side (i.e. we follow inclusion graph) for processing
+                // We might be updating left side, in that case we need to process all nodes that contain the variables from the left,
+                // i.e. those nodes to which node_to_process goes to. In the case we are updating right side, there will be no edges
+                // coming from node_to_process, so this for loop will do nothing.
                 for (const auto &node : element_to_process.inclusion_graph->get_edges_from(node_to_process)) {
                     // we push only those nodes which are not already in nodes_to_process
                     // if the node_to_process is on cycle, we need to do BFS
@@ -149,7 +172,7 @@ namespace smt::noodler {
                 element_to_process.substitution_map.merge(substitution_map);
 
                 // TODO: should we really push to front when not on cycle?
-                // TODO: maybe for this case of one side being empty, we should just push to front? 
+                // TODO: maybe for this case of one side being empty, we should just push to front?
                 if (!is_node_to_process_on_cycle) {
                     worklist.push_front(element_to_process);
                 } else {
@@ -157,65 +180,119 @@ namespace smt::noodler {
                 }
                 continue;
             }
+            /********************************************************************************************************/
+            /*************************************** End of one side is empty ***************************************/
+            /********************************************************************************************************/
 
-            /** process left side **/
+
+
+            /********************************************************************************************************/
+            /****************************************** Process left side *******************************************/
+            /********************************************************************************************************/
             std::vector<std::shared_ptr<Mata::Nfa::Nfa>> left_side_automata;
             STRACE("str-nfa", tout << "Left automata:" << std::endl);
             for (const auto &l_var : left_side_vars) {
                 left_side_automata.push_back(element_to_process.aut_ass.at(l_var));
-                STRACE("str-nfa", left_side_automata.back()->print_to_DOT(tout););
+                STRACE("str-nfa",
+                    tout << "Automaton for left var " << l_var.get_name() << ":" << std::endl;
+                    left_side_automata.back()->print_to_DOT(tout);
+                );
             }
-            /** end of left side processing **/
+            /********************************************************************************************************/
+            /************************************** End of left side processing *************************************/
+            /********************************************************************************************************/
 
 
-            /** Combine the right side into automata where we concatenate non-length-aware vars next to each other **/
+
+
+            /********************************************************************************************************/
+            /***************************************** Process right side *******************************************/
+            /********************************************************************************************************/
+            // We combine the right side into automata where we concatenate non-length-aware vars next to each other.
+            // Each right side automaton corresponds to either concatenation of non-length-aware vars (vector of
+            // basic terms) or one lenght-aware var (vector of one basic term). Division then contains for each right
+            // side automaton the variables whose concatenation it represents.
             std::vector<std::shared_ptr<Mata::Nfa::Nfa>> right_side_automata;
-            // each right side automaton corresponds to either concatenation of non-length-aware vars (vector of basic terms) or one lenght-aware var (vector of one basic term)
             std::vector<std::vector<BasicTerm>> right_side_division;
-            assert(!right_side_vars.empty());
+
+            assert(!right_side_vars.empty()); // empty case was processed at the beginning
             auto right_var_it = right_side_vars.begin();
             auto right_side_end = right_side_vars.end();
 
             std::shared_ptr<Mata::Nfa::Nfa> next_aut = element_to_process.aut_ass[*right_var_it];
             std::vector<BasicTerm> next_division{ *right_var_it };
             bool last_was_length = (element_to_process.length_sensitive_vars.count(*right_var_it) > 0);
+            bool is_there_length_on_right = last_was_length;
             ++right_var_it;
 
+            STRACE("str-nfa", tout << "Right automata:" << std::endl);
             for (; right_var_it != right_side_end; ++right_var_it) {
                 std::shared_ptr<Mata::Nfa::Nfa> right_var_aut = element_to_process.aut_ass.at(*right_var_it);
                 if (element_to_process.length_sensitive_vars.count(*right_var_it) > 0) {
                     // current right_var is length-aware
                     right_side_automata.push_back(next_aut);
                     right_side_division.push_back(next_division);
+                    STRACE("str-nfa",
+                        tout << "Automaton for right var(s)";
+                        for (const auto &r_var : next_division) {
+                            tout << " " << r_var.get_name();
+                        }
+                        tout << ":" << std::endl;
+                        next_aut->print_to_DOT(tout);
+                    );
                     next_aut = right_var_aut;
                     next_division = std::vector<BasicTerm>{ *right_var_it };
                     last_was_length = true;
+                    is_there_length_on_right = true;
                 } else {
                     // current right_var is not length-aware
                     if (last_was_length) {
+                        // if last var was length-aware, we need to add automaton for it into right_side_automata
                         right_side_automata.push_back(next_aut);
                         right_side_division.push_back(next_division);
+                        STRACE("str-nfa",
+                            tout << "Automaton for right var(s)";
+                            for (const auto &r_var : next_division) {
+                                tout << " " << r_var.get_name();
+                            }
+                            tout << ":" << std::endl;
+                            next_aut->print_to_DOT(tout);
+                        );
                         next_aut = right_var_aut;
                         next_division = std::vector<BasicTerm>{ *right_var_it };
                     } else {
+                        // if last var was not length-aware, we combine it (and possibly the non-length-aware vars before)
+                        // with the current one
                         next_aut = std::make_shared<Mata::Nfa::Nfa>(Mata::Nfa::concatenate(*next_aut, *right_var_aut));
                         next_division.push_back(*right_var_it);
-                        // TODO probably reduce size here
+                        // TODO should we reduce size here?
                     }
                     last_was_length = false;
                 }
             }
             right_side_automata.push_back(next_aut);
-            STRACE("str-nfa", tout << "Right automata:" << std::endl);
-            STRACE("str-nfa", right_side_automata.back()->print_to_DOT(tout););
             right_side_division.push_back(next_division);
-            /** end of right side combining **/
+            STRACE("str-nfa",
+                tout << "Automaton for right var(s)";
+                for (const auto &r_var : next_division) {
+                    tout << " " << r_var.get_name();
+                }
+                tout << ":" << std::endl;
+                next_aut->print_to_DOT(tout);
+            );
+            /********************************************************************************************************/
+            /************************************* End of right side processing *************************************/
+            /********************************************************************************************************/
 
+
+            /********************************************************************************************************/
+            /****************************************** Inclusion test **********************************************/
+            /********************************************************************************************************/
             if (!is_there_length_on_right) {
                 // we have no length-aware variables on the right hand side => we need to check if inclusion holds
                 assert(right_side_automata.size() == 1); // there should be exactly one element in right_side_automata as we do not have length variables
                 // TODO probably we should try shortest words, it might work correctly
-                if (is_node_to_process_on_cycle // TODO should we not test inclusion if we have node that is not on cycle? because we will not go back to it, so it should make sense to just do noodlification
+                if (is_node_to_process_on_cycle // we do not test inclusion if we have node that is not on cycle, because we will not go back to it (TODO: should we really not test it?)
                     && Mata::Nfa::is_included(element_to_process.aut_ass.get_automaton_concat(left_side_vars), *right_side_automata[0])) {
                     // TODO can I push to front? I think I can, and I probably want to, so I can immediately test if it is not sat (if element_to_process.nodes_to_process is empty), or just to get to sat faster
                     worklist.push_front(element_to_process);
@@ -223,9 +300,15 @@ namespace smt::noodler {
                     continue;
                 }
             }
+            /********************************************************************************************************/
+            /*************************************** End of inclusion test ******************************************/
+            /********************************************************************************************************/
 
-            // we are going to change the automata on the left side (potentially also split some on the right side, but that should not have impact)
-            // so we need to add all nodes whose variable assignments are going to change on the right side (i.e. we follow inclusion graph) for processing
+
+            // We are going to change the automata on the left side (potentially also split some on the right side, but that should not have impact)
+            // so we need to add all nodes whose variable assignments are going to change on the right side (i.e. we follow inclusion graph) for processing.
+            // Warning: Self-loops are not in inclusion graph, but we might still want to add this node again to nodes_to_process, however, this node will be
+            // split during noodlification, so we will only add parts whose right sides actually change (see below in noodlification)
             for (const auto &node : element_to_process.inclusion_graph->get_edges_from(node_to_process)) {
                 // we push only those nodes which are not already in nodes_to_process
                 // if the node_to_process is on cycle, we need to do BFS
@@ -233,6 +316,9 @@ namespace smt::noodler {
                 // TODO: can we really do DFS??
                 element_to_process.push_unique(node, is_node_to_process_on_cycle);
             }
+            // We will need the set of left vars, so we can sort the 'non-existing self-loop' in noodlification (see previous warning)
+            const auto left_vars_set = node_to_process->get_predicate().get_left_set();
+
 
             /* TODO check here if we have empty elements_to_process, if we do, then every noodle we get should finish and return sat
              * right now if we test sat at the beginning it should work, but it is probably better to immediatly return sat if we have
@@ -240,15 +326,22 @@ namespace smt::noodler {
              * and process them if z3 realizes that the result is actually not sat (because of lengths)
              */
 
+            
 
-
+            /********************************************************************************************************/
+            /******************************************* Noodlification *********************************************/
+            /********************************************************************************************************/
             /**
-             * We get noodles where each noodle consists of automata connected with a vector of numbers
-             * So for example if we have some noodle and automaton noodle[i].first, then noodle[i].second is a vector, where first element
-             * i_l = noodle[i].second[0] tells us that automaton noodle[i].first belongs to the i_l-th left var (i.e. left_side_vars[i_l])
-             * and the second element i_r = noodle[i].second[1] tell us that it belongs to the i_r-th division of the right side (i.e. right_side_division[i_r])
+             * We get noodles where each noodle consists of automata connected with a vector of numbers.
+             * So for example if we have some noodle and automaton noodle[i].first, then noodle[i].second is a vector,
+             * where first element i_l = noodle[i].second[0] tells us that automaton noodle[i].first belongs to the
+             * i_l-th left var (i.e. left_side_vars[i_l]) and the second element i_r = noodle[i].second[1] tell us that
+             * it belongs to the i_r-th division of the right side (i.e. right_side_division[i_r])
              **/
-            auto noodles = Mata::Strings::SegNfa::noodlify_for_equation(left_side_automata, right_side_automata, false, {{"reduce", "true"}});
+            auto noodles = Mata::Strings::SegNfa::noodlify_for_equation(left_side_automata, 
+                                                                        right_side_automata,
+                                                                        false, 
+                                                                        {{"reduce", "true"}});
 
             for (const auto &noodle : noodles) {
                 SolvingState new_element = element_to_process;
@@ -259,6 +352,19 @@ namespace smt::noodler {
                 //remove processed inclusion from the inclusion graph
                 new_element.inclusion_graph->remove_node(new_node_to_process); // TODO: is this safe?
 
+                /* Explanation of the next code on an example:
+                 * Left side has variables x_1, x_2, x_3, x_2 while the right side has variables x_4, x_1, x_5, x_6, where x_1
+                 * and x_4 are length-aware (i.e. there is one automaton for concatenation of x_5 and x_6 on the right side).
+                 * Assume that noodle represents the case where it was split like this:
+                 *              | x_1 |    x_2    | x_3 |       x_2       |
+                 *              | t_1 | t_2 | t_3 | t_4 | t_5 |    t_6    |
+                 *              |    x_4    |       x_1       | x_5 | x_6 |
+                 * In the following for loop, we create the vars t1, t2, ..., t6 and prepare two vectors left_side_vars_to_new_vars
+                 * and right_side_divisions_to_new_vars which map left vars and right divisions into the concatenation of the new
+                 * vars. So for example left_side_vars_to_new_vars[1] = t_2 t_3, because second left var is x_2 and we map it to t_2 t_3,
+                 * while right_side_divisions_to_new_vars[2] = t_6, because the third division on the right represents the automaton for
+                 * concatenation of x_5 and x_6 and we map it to t_6.
+                 */
                 std::vector<std::vector<BasicTerm>> left_side_vars_to_new_vars(left_side_vars.size());
                 std::vector<std::vector<BasicTerm>> right_side_divisions_to_new_vars(right_side_division.size());
                 for (unsigned i = 0; i < noodle.size(); ++i) {
@@ -270,50 +376,80 @@ namespace smt::noodler {
                     new_element.aut_ass[new_var] = noodle[i].first; // we assign the automaton to new_var
                 }
 
+                // Each variable that occurs in the left side or is length-aware needs to be substituted, we use this map for that 
                 std::unordered_map<BasicTerm, std::vector<BasicTerm>> substitution_map;
 
+                /* Following the example from before, the following loop will create these inclusions from the right side divisions:
+                 *         t_1 t_2 ⊆ x_4
+                 *     t_3 t_4 t_5 ⊆ x_1
+                 *             t_6 ⊆ x_5 x_6
+                 * However, we do not add the first two inclusions into the inclusion graph but use them for substitution, i.e.
+                 *        substitution_map[x_4] = t_1 t_2
+                 *        substitution_map[x_1] = t_3 t_4 t_5
+                 * because they are length-aware vars.
+                 */
                 for (unsigned i = 0; i < right_side_division.size(); ++i) {
                     const auto &division = right_side_division[i];
                     if (division.size() == 1 && element_to_process.length_sensitive_vars.count(division[0]) != 0) {
-                        // right side is length-aware variable y => we are either substituting or adding new inclusion "new_vars included in y"
+                        // right side is length-aware variable y => we are either substituting or adding new inclusion "new_vars ⊆ y"
                         const BasicTerm &right_var = division[0];
                         if (substitution_map.count(right_var)) {
-                            // right_var is already substituted, therefore we add 'new_vars included in right_var' to the inclusion graph
+                            // right_var is already substituted, therefore we add 'new_vars ⊆ right_var' to the inclusion graph
                             const auto &new_inclusion = new_element.inclusion_graph->add_node(right_side_divisions_to_new_vars[i], division);
                             // we also add this inclusion to the worklist, as it represents unification
                             // we push it to the front if we are processing node that is not on the cycle, because it should not get stuck in the cycle then
                             // TODO: is this correct? can we push to the front?
+                            // TODO: can't we push to front even if it is on cycle??
                             new_element.push_unique(new_inclusion, is_node_to_process_on_cycle);
                         } else {
                             // right_var is not substitued by anything yet, we will substitute it
                             substitution_map[right_var] = right_side_divisions_to_new_vars[i];
-                            STRACE("str", tout << "left side var " << right_var.get_name() << " replaced with:"; for (auto const &var : right_side_divisions_to_new_vars[i]) { tout << " " << var.get_name(); } tout << std::endl; );
+                            STRACE("str", tout << "right side var " << right_var.get_name() << " replaced with:"; for (auto const &var : right_side_divisions_to_new_vars[i]) { tout << " " << var.get_name(); } tout << std::endl; );
                             // as right_var wil be substituted in the inclusion graph, we do not need to remember the automaton assignment for it
                             new_element.aut_ass.erase(right_var);
                             // update the length variables
-                            // TODO: is this enough to update variables only when substituting?
                             for (const BasicTerm &new_var : right_side_divisions_to_new_vars[i]) {
                                 new_element.length_sensitive_vars.insert(new_var);
                             }
                         }
 
                     } else {
-                        // right side is non-length concatenation "y_1...y_n" => we are adding new inclusion "new_vars included in y1...y_n"
-                        new_element.inclusion_graph->add_node(right_side_divisions_to_new_vars[i], division);
-                        // we do not add the new inclusion to the worklist, because it represents the part of the inclusion that "was not split", i.e. it was processed in FM way
+                        // right side is non-length concatenation "y_1...y_n" => we are adding new inclusion "new_vars ⊆ y1...y_n"
+                        const auto &new_inclusion = new_element.inclusion_graph->add_node(right_side_divisions_to_new_vars[i], division);
+                        // we add this inclusion to the worklist only if the right side contains something that was on the left (i.e. it was possibly changed)
+                        for (const auto &right_var : division) {
+                            if (left_vars_set.count(right_var) > 0) {
+                                // TODO: again, push to front? back? where the fuck to push??
+                                new_element.push_unique(new_inclusion, is_node_to_process_on_cycle);
+                                break;
+                            }
+                        }
                     }
                 }
 
+                /* Following the example from before, the following loop will create these inclusions from the left side:
+                 *           x_1 ⊆ t_1
+                 *           x_2 ⊆ t_2 t_3
+                 *           x_3 ⊆ t_4
+                 *           x_2 ⊆ t_5 t_6
+                 * Again, we want to use the inclusions for substitutions, but we replace only those variables which were
+                 * not substituted yet, so the first inclusion stays (x_1 was substituted from the right side) and the
+                 * fourth inclusion stays (as we substitute x_2 using the second inclusion). So from the second and third
+                 * inclusion we get:
+                 *        substitution_map[x_2] = t_2 t_3
+                 *        substitution_map[x_3] = t_4
+                 */
                 for (unsigned i = 0; i < left_side_vars.size(); ++i) {
                     // TODO maybe if !is_there_length_on_right, we should just do intersection and not create new inclusions
                     const BasicTerm &left_var = left_side_vars[i];
                     if (substitution_map.count(left_var)) {
-                        // left_var is already substituted, therefore we add 'left_var included in left_side_vars_to_new_vars[i]' to the inclusion graph
+                        // left_var is already substituted, therefore we add 'left_var ⊆ left_side_vars_to_new_vars[i]' to the inclusion graph
                         std::vector<BasicTerm> new_inclusion_left_side{ left_var };
                         const auto &new_inclusion = new_element.inclusion_graph->add_node(new_inclusion_left_side, left_side_vars_to_new_vars[i]);
                         // we also add this inclusion to the worklist, as it represents unification
                         // we push it to the front if we are processing node that is not on the cycle, because it should not get stuck in the cycle then
                         // TODO: is this correct? can we push to the front?
+                        // TODO: can't we push to front even if it is on cycle??
                         new_element.push_unique(new_inclusion, is_node_to_process_on_cycle);
                     } else {
                         // TODO make this function or something, we do the same thing here as for the right side when substituting
@@ -323,7 +459,6 @@ namespace smt::noodler {
                         // as left_var wil be substituted in the inclusion graph, we do not need to remember the automaton assignment for it
                         new_element.aut_ass.erase(left_var);
                         // update the length variables
-                        // TODO: is this enough to update variables only when substituting?
                         if (new_element.length_sensitive_vars.count(left_var) > 0) { // if left_var is length-aware => substituted vars should become length-aware
                             for (const BasicTerm &new_var : left_side_vars_to_new_vars[i]) {
                                 new_element.length_sensitive_vars.insert(new_var);
@@ -352,9 +487,14 @@ namespace smt::noodler {
 
             }
 
-            ++noodlification_no; // TODO: when to do this increment??
+            ++noodlification_no; // TODO: when to do this increment?? maybe noodlification_no should be part of SolvingState?
+            /********************************************************************************************************/
+            /*************************************** End of noodlification ******************************************/
+            /********************************************************************************************************/
+
         }
 
+        // there are no solving states left, which means nothing led to solution -> it must be unsatisfiable
         return false;
     }
 

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -644,31 +644,10 @@ namespace smt::noodler {
         return true;
     }
 
-    // void DecisionProcedure::remove_literals_from_formula() {
-    //     unsigned literal_no = 0;
-    //     auto replace_in_vector = [&literal_no, this](std::vector<BasicTerm> &term_vec) {
-    //         for (size_t i = 0; i < term_vec.size(); ++i) {
-    //             BasicTerm &term = term_vec[i];
-    //             if (term.is_literal()) {
-    //                 BasicTerm new_var{BasicTermType::Variable, }
-    //             }
-    //         }
-    //         for (auto &term : term_vec) {
-    //             if (term.is) {
-    //                 term.
-    //             }
-    //         }
-    //     };
-    //     for (const auto &predicate : this->formula.get_predicates()) {
-    //         for (const auto &side : predicate.)
-    //     }
-    // }
-
     /**
      * @brief Creates initial inclusion graph according to the preprocessed instance.
      */
     void DecisionProcedure::init_computation() {
-        // remove_literals_from_formula();
         SolvingState initialWlEl;
         initialWlEl.length_sensitive_vars = this->init_length_sensitive_vars;
         initialWlEl.aut_ass = std::move(this->init_aut_ass);

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -8,21 +8,6 @@
 #include "decision_procedure.h"
 
 namespace smt::noodler {
-    // std::shared_ptr<GraphNode> SolvingState::make_deep_copy_of_inclusion_graph_only_nodes(std::shared_ptr<GraphNode> processed_node) {
-    //     assert(inclusion_graph->get_nodes().count(processed_node) > 0);
-    //     Graph graph_to_copy = *inclusion_graph;
-    //     graph_to_copy.remove_all_edges();
-    //     assert(graph_to_copy.get_nodes().count(processed_node) > 0);
-    //     std::unordered_map<std::shared_ptr<GraphNode>, std::shared_ptr<GraphNode>> node_mapping;
-    //     inclusion_graph = std::make_shared<Graph>(graph_to_copy.deep_copy(node_mapping));
-    //     std::deque<std::shared_ptr<GraphNode>> new_nodes_to_process;
-    //     while (!inclusions_to_process.empty()) {
-    //         new_nodes_to_process.push_back(node_mapping.at(inclusions_to_process.front()));
-    //         inclusions_to_process.pop_front();
-    //     }
-    //     inclusions_to_process = new_nodes_to_process;
-    //     return node_mapping.at(processed_node);
-    // }
 
     void SolvingState::substitute_vars(std::unordered_map<BasicTerm, std::vector<BasicTerm>> &substitution_map) {
         // substitutes variables in a vector using substitution_map

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -680,7 +680,7 @@ namespace smt::noodler {
             this->init_aut_ass.reduce(); // reduce all automata in the automata assignment
         }
 
-        STRACE("str", tout << "preprocess-output: " << std::endl << this->formula.to_string() << "\n" );
+        STRACE("str", tout << "preprocess-output:" << std::endl << this->formula.to_string() << std::endl; );
     }
 
     /**

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -94,7 +94,10 @@ namespace smt::noodler {
             element_to_process.nodes_to_process.pop_front();
             assert(node_to_process != nullptr);
 
-            STRACE("str", tout << "Processing node with inclusion " << node_to_process->get_predicate() <<std::endl;);
+            // this will decide whether we will continue in our search by DFS or by BFS
+            bool is_node_to_process_on_cycle = element_to_process.inclusion_graph->is_on_cycle(node_to_process);
+
+            STRACE("str", tout << "Processing node with inclusion " << node_to_process->get_predicate() << " which is" << (is_node_to_process_on_cycle ? " " : " not ") << "on the cycle" << std::endl;);
             STRACE("str", tout << "Length variables are:"; 
                           for(auto const &var : node_to_process->get_predicate().get_vars()) {
                               if (element_to_process.length_sensitive_vars.count(var)) {
@@ -106,10 +109,6 @@ namespace smt::noodler {
 
             const auto &left_side_vars = node_to_process->get_predicate().get_left_side();
             const auto &right_side_vars = node_to_process->get_predicate().get_right_side();
-
-            // this will decide whether we will continue in our search by DFS or by BFS
-            bool is_node_to_process_on_cycle = element_to_process.inclusion_graph->is_on_cycle(node_to_process);
-
 
             /********************************************************************************************************/
             /****************************************** One side is empty *******************************************/

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -124,7 +124,6 @@ namespace smt::noodler {
             // i.e. we will update automata assignments and substitutions so that this inclusion is fulfilled
             Predicate inclusion_to_process = element_to_process.inclusions_to_process.front();
             element_to_process.inclusions_to_process.pop_front();
-            assert(inclusion_to_process != nullptr);
 
             // this will decide whether we will continue in our search by DFS or by BFS
             bool is_inclusion_to_process_on_cycle = element_to_process.is_inclusion_on_cycle(inclusion_to_process);

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -680,7 +680,7 @@ namespace smt::noodler {
             this->init_aut_ass.reduce(); // reduce all automata in the automata assignment
         }
 
-        STRACE("str", tout << "preprocess-output: " << this->formula.to_string() << "\n" );
+        STRACE("str", tout << "preprocess-output: " << std::endl << this->formula.to_string() << "\n" );
     }
 
     /**

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -145,7 +145,7 @@ namespace smt::noodler {
             /********************************************************************************************************/
             /****************************************** One side is empty *******************************************/
             /********************************************************************************************************/
-            // As kinda opmtimalization step, we do "noodlification" for empty sides separately (i.e. sides that
+            // As kinda optimization step, we do "noodlification" for empty sides separately (i.e. sides that
             // represent empty string). This is because it is simpler, we would get only one noodle so we just need to
             // check that the non-empty side actually contains empty string and replace the vars on that side by epsilon.
             if (right_side_vars.empty() || left_side_vars.empty()) {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -76,6 +76,10 @@ namespace smt::noodler {
     bool DecisionProcedure::compute_next_solution() {
         // iteratively select next state of solving that can lead to solution and
         // process one of the unprocessed nodes (or possibly find solution)
+        STRACE("str", tout << "------------------------"
+                           << "Getting another solution"
+                           << "------------------------" << std::endl;);
+
         while (!worklist.empty()) {
             SolvingState element_to_process = std::move(worklist.front());
             worklist.pop_front();
@@ -98,14 +102,15 @@ namespace smt::noodler {
             bool is_node_to_process_on_cycle = element_to_process.inclusion_graph->is_on_cycle(node_to_process);
 
             STRACE("str", tout << "Processing node with inclusion " << node_to_process->get_predicate() << " which is" << (is_node_to_process_on_cycle ? " " : " not ") << "on the cycle" << std::endl;);
-            STRACE("str", tout << "Length variables are:"; 
-                          for(auto const &var : node_to_process->get_predicate().get_vars()) {
-                              if (element_to_process.length_sensitive_vars.count(var)) {
-                                  tout << " " << var.to_string();
-                              }
-                          }
-                          tout << std::endl;
-                          );
+            STRACE("str",
+                tout << "Length variables are:";
+                for(auto const &var : node_to_process->get_predicate().get_vars()) {
+                    if (element_to_process.length_sensitive_vars.count(var)) {
+                        tout << " " << var.to_string();
+                    }
+                }
+                tout << std::endl;
+            );
 
             const auto &left_side_vars = node_to_process->get_predicate().get_left_side();
             const auto &right_side_vars = node_to_process->get_predicate().get_right_side();

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -424,13 +424,13 @@ namespace smt::noodler {
                         // TODO: how to decide if sometihng is on cycle? by previous node being on cycle, or when we recompute inclusion graph edges?
                         new_element.inclusion_graph->set_is_on_cycle(new_inclusion, is_node_to_process_on_cycle);
                         // we add this inclusion to the worklist only if the right side contains something that was on the left (i.e. it was possibly changed)
-                        for (const auto &right_var : division) {
-                            if (left_vars_set.count(right_var) > 0) {
-                                // TODO: again, push to front? back? where the fuck to push??
-                                new_element.push_unique(new_inclusion, is_node_to_process_on_cycle);
-                                break;
-                            }
-                        }
+                        // for (const auto &right_var : division) {
+                        //     if (left_vars_set.count(right_var) > 0) {
+                        //         // TODO: again, push to front? back? where the fuck to push??
+                        //         new_element.push_unique(new_inclusion, is_node_to_process_on_cycle);
+                        //         break;
+                        //     }
+                        // }
                         STRACE("str", tout << "added new inclusion from the right side (non-length): " << new_inclusion->get_predicate() << std::endl; );
                     }
                 }

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -129,14 +129,12 @@ namespace smt::noodler {
         SolvingState() = default;
         SolvingState(AutAssignment aut_ass,
                      std::deque<Predicate> inclusions_to_process,
-                     //std::shared_ptr<Graph> inclusion_graph,
                      std::set<Predicate> inclusions,
                      std::set<Predicate> inclusions_not_on_cycle,
                      std::unordered_set<BasicTerm> length_sensitive_vars,
                      std::unordered_map<BasicTerm, std::vector<BasicTerm>> substitution_map)
                         : aut_ass(aut_ass),
                           substitution_map(substitution_map),
-                          //inclusion_graph(inclusion_graph),
                           inclusions(inclusions),
                           inclusions_not_on_cycle(inclusions_not_on_cycle),
                           inclusions_to_process(inclusions_to_process),

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -216,8 +216,9 @@ namespace smt::noodler {
          */
         std::vector<Predicate> get_dependent_inclusions(const Predicate &inclusion) {
             std::vector<Predicate> dependent_inclusions;
+            auto left_vars_set = inclusion.get_left_set();
             for (const Predicate &other_inclusion : inclusions) {
-                if (is_dependent(inclusion, other_inclusion)) {
+                if (is_dependent(left_vars_set, other_inclusion.get_right_set())) {
                     dependent_inclusions.push_back(other_inclusion);
                 }
             }
@@ -225,16 +226,15 @@ namespace smt::noodler {
         }
 
         /**
-         * Check if @p inclusion_to_depend depends on @p inclusion in the inclusion graph, i.e.
-         * if right side of @p inclusion_to_depend contain variable from the left side of @p inclusion.
+         * Check if the vector @p right_side_vars depends on @p left_side_vars, i.e. if some variable
+         * (NOT literal) occuring in @p right_side_vars occurs also in @p left_side_vars
          */
-        bool is_dependent(const Predicate &inclusion, const Predicate &inclusion_to_depend) {
-            auto const &left_side_vars =  inclusion.get_left_set();
+        static bool is_dependent(const std::set<BasicTerm> &left_side_vars, const std::set<BasicTerm> &right_side_vars) {
             if (left_side_vars.empty()) {
                 return false;
             }
-            for (auto const &right_var : inclusion_to_depend.get_right_set()) {
-                if (left_side_vars.count(right_var) > 0) {
+            for (auto const &right_var : right_side_vars) {
+                if (right_var.is_variable() && left_side_vars.count(right_var) > 0) {
                     return true;
                 }
             }
@@ -305,6 +305,12 @@ namespace smt::noodler {
         expr_ref get_subs_map_len(std::map<BasicTerm, expr_ref>& variable_map, const SolvingState& state);
 
         bool check_diseqs(const AutAssignment& ass);
+
+        /**
+         * Replaces each occurence of a literal in formula by a new variable.
+         * 
+         */
+        // void remove_literals_from_formula();
 
     public:
         DecisionProcedure(ast_manager& m, seq_util& m_util_s, arith_util& m_util_a);

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -306,12 +306,6 @@ namespace smt::noodler {
 
         bool check_diseqs(const AutAssignment& ass);
 
-        /**
-         * Replaces each occurence of a literal in formula by a new variable.
-         * 
-         */
-        // void remove_literals_from_formula();
-
     public:
         DecisionProcedure(ast_manager& m, seq_util& m_util_s, arith_util& m_util_a);
         

--- a/src/smt/theory_str_noodler/inclusion_graph.cc
+++ b/src/smt/theory_str_noodler/inclusion_graph.cc
@@ -237,7 +237,7 @@ Graph smt::noodler::Graph::create_inclusion_graph(Graph& simplified_splitting_gr
         for (auto& node: simplified_splitting_graph.get_nodes()) {
             if (simplified_splitting_graph.inverse_edges.count(node) == 0) {
                 inclusion_graph.nodes.insert(node);
-                STRACE("str", tout << "Added node " << node->get_predicate() << " to the graph without its brother." << std::endl;);
+                STRACE("str", tout << "Added node " << node->get_predicate() << " to the graph without the reversed inclusion." << std::endl;);
                 inclusion_graph.nodes_not_on_cycle.insert(node); // the inserted node cannot be on the cycle, because it is either initial or all nodes leading to it were not on cycle
 
                 out_node_order.push_back(node);
@@ -261,7 +261,7 @@ Graph smt::noodler::Graph::create_inclusion_graph(Graph& simplified_splitting_gr
     // we add rest of the nodes (the ones on the cycle) to the inclusion graph
     for (auto& node: simplified_splitting_graph.get_nodes()) {
         out_node_order.push_back(node);
-        STRACE("str", tout << "Added node " << node->get_predicate() << " to the graph with its brother." << std::endl;);
+        STRACE("str", tout << "Added node " << node->get_predicate() << " to the graph with its reversed inclusion." << std::endl;);
     }
     inclusion_graph.nodes.merge(simplified_splitting_graph.nodes);
 

--- a/src/smt/theory_str_noodler/inclusion_graph.cc
+++ b/src/smt/theory_str_noodler/inclusion_graph.cc
@@ -213,14 +213,6 @@ Graph smt::noodler::Graph::create_simplified_splitting_graph(const Formula& form
         }
     }
 
-    // initial nodes TODO: do we need them???
-    for (auto& node: graph.get_nodes()) {
-        // auto node{ const_cast<GraphNode *>(&const_node) };
-        if (graph.inverse_edges.count(node) == 0) {
-            graph.initial_nodes.insert(node);
-        }
-    }
-
     return graph;
 }
 
@@ -240,9 +232,6 @@ Graph smt::noodler::Graph::create_inclusion_graph(Graph& simplified_splitting_gr
             if (simplified_splitting_graph.inverse_edges.count(node) == 0) {
                 inclusion_graph.nodes.insert(node);
                 inclusion_graph.nodes_not_on_cycle.insert(node); // the inserted node cannot be on the cycle, because it is either initial or all nodes leading to it were not on cycle
-                if (simplified_splitting_graph.initial_nodes.count(node) > 0) {
-                    inclusion_graph.initial_nodes.insert(node);
-                }
 
                 out_node_order.push_back(node);
 
@@ -262,9 +251,8 @@ Graph smt::noodler::Graph::create_inclusion_graph(Graph& simplified_splitting_gr
         }
     }
 
-    // we add rest of the nodes (the ones on the cycle) to the inclusion graph and make them initial
+    // we add rest of the nodes (the ones on the cycle) to the inclusion graph
     for (auto& node: simplified_splitting_graph.get_nodes()) {
-        inclusion_graph.initial_nodes.insert(node);
         out_node_order.push_back(node);
     }
     inclusion_graph.nodes.merge(simplified_splitting_graph.nodes);

--- a/src/smt/theory_str_noodler/inclusion_graph.cc
+++ b/src/smt/theory_str_noodler/inclusion_graph.cc
@@ -82,6 +82,12 @@ Graph smt::noodler::Graph::deep_copy(std::unordered_map<std::shared_ptr<GraphNod
         }
     }
 
+    for (const auto &node_not_on_cycle : nodes_not_on_cycle) {
+        if (get_nodes().count(node_not_on_cycle) > 0) {
+            new_graph.nodes_not_on_cycle.insert(node_mapping.at(node_not_on_cycle));
+        }
+    }
+
     return new_graph;
 }
 
@@ -231,6 +237,7 @@ Graph smt::noodler::Graph::create_inclusion_graph(Graph& simplified_splitting_gr
         for (auto& node: simplified_splitting_graph.get_nodes()) {
             if (simplified_splitting_graph.inverse_edges.count(node) == 0) {
                 inclusion_graph.nodes.insert(node);
+                STRACE("str", tout << "Added node " << node->get_predicate() << " to the graph without its brother." << std::endl;);
                 inclusion_graph.nodes_not_on_cycle.insert(node); // the inserted node cannot be on the cycle, because it is either initial or all nodes leading to it were not on cycle
 
                 out_node_order.push_back(node);
@@ -254,6 +261,7 @@ Graph smt::noodler::Graph::create_inclusion_graph(Graph& simplified_splitting_gr
     // we add rest of the nodes (the ones on the cycle) to the inclusion graph
     for (auto& node: simplified_splitting_graph.get_nodes()) {
         out_node_order.push_back(node);
+        STRACE("str", tout << "Added node " << node->get_predicate() << " to the graph with its brother." << std::endl;);
     }
     inclusion_graph.nodes.merge(simplified_splitting_graph.nodes);
 

--- a/src/smt/theory_str_noodler/inclusion_graph.h
+++ b/src/smt/theory_str_noodler/inclusion_graph.h
@@ -187,7 +187,7 @@ namespace smt::noodler {
             return (nodes_not_on_cycle.count(node) == 0);
         }
 
-        bool set_is_on_cycle(const std::shared_ptr<GraphNode> &node, bool is_on_cycle) {
+        void set_is_on_cycle(const std::shared_ptr<GraphNode> &node, bool is_on_cycle) {
             assert(nodes.count(node) > 0);
             if (!is_on_cycle) {
                 nodes_not_on_cycle.insert(node);

--- a/src/smt/theory_str_noodler/inclusion_graph.h
+++ b/src/smt/theory_str_noodler/inclusion_graph.h
@@ -187,6 +187,13 @@ namespace smt::noodler {
             return (nodes_not_on_cycle.count(node) == 0);
         }
 
+        bool set_is_on_cycle(const std::shared_ptr<GraphNode> &node, bool is_on_cycle) {
+            assert(nodes.count(node) > 0);
+            if (!is_on_cycle) {
+                nodes_not_on_cycle.insert(node);
+            }
+        }
+
         // adds edges so that inclusions x and y where left side of x shares variable with right side of y have edge from x to y
         void add_inclusion_graph_edges();
 

--- a/src/smt/theory_str_noodler/inclusion_graph.h
+++ b/src/smt/theory_str_noodler/inclusion_graph.h
@@ -58,11 +58,6 @@ namespace smt::noodler {
         Edges edges;
         Edges inverse_edges;
         static const Nodes empty_nodes;
-        // set of nodes that do not have edge coming to them
-        // it is guaranteed to be correct ONLY after creating splitting/inclusion graph
-        // methods adding/removing edges DO NOT UPDATE this set, i.e. IT MIGHT NOT BE CORRECT
-        // TODO: probably not needed
-        std::unordered_set<std::shared_ptr<GraphNode>> initial_nodes;
         // set of nodes that are NOT on some cycle
         // it is guaranteed to be correct ONLY after creating inclusion graph???
         std::unordered_set<std::shared_ptr<GraphNode>> nodes_not_on_cycle;


### PR DESCRIPTION
I added more explanatory comments to decision procedure and tried to at least visually divide the different parts in it. Also a fix for the previous fix, empty sides should now propagate properly even for left side vars. There are also some more fixes (computing which new nodes are on cycle, or propagating that the change on the left in the same inclusion should add the same node to be processed again). I also removed inclusion graph from the decision procedure and moved all the inclusions keeping into the `SolvingState`, inclusion graph is now called only at the initialization.