### PR TITLE
Compiling with new mata

### DIFF
--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -537,7 +537,7 @@ namespace smt::noodler::util {
     }
 
     Nfa create_word_nfa(const zstring& word) {
-        const size_t word_length{ word.length() };
+        const unsigned word_length{ word.length() };
         Mata::OnTheFlyAlphabet* mata_alphabet{ new Mata::OnTheFlyAlphabet{} };
         for (size_t i{ 0 }; i < word_length; ++i) {
             mata_alphabet->try_add_new_symbol(std::to_string(word[i]), word[i]);


### PR DESCRIPTION
Small fix so we can compile on mac with newest version of Mata (related to changing states from unsigned long to unsigned).