### PR TITLE
Add support for more operations

### DIFF
--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -50,7 +50,8 @@ namespace smt::noodler::util {
             }
             extract_symbols(to_app(arg), m_util_s, m, alphabet);
             return;
-        } else if (m_util_s.re.is_concat(ex_app) // Handle concatenation.
+        } else if (m_util_s.re.is_concat(ex_app) // Handle regex concatenation.
+                || m_util_s.str.is_concat(ex_app) // Handle string concatenation.
                 || m_util_s.re.is_intersection(ex_app) // Handle intersection.
             ) {
             for (unsigned int i = 0; i < ex_app->get_num_args(); ++i) {
@@ -123,14 +124,7 @@ namespace smt::noodler::util {
         } else if(is_variable(ex_app, m_util_s)) { // Handle variable.
             throw_error("variable should not occur here");
         } else {
-            throw_error("something unsupported");
-
-            // When ex is not string literal, variable, nor regex, recursively traverse the AST to find symbols.
-            for(unsigned i = 0; i < ex_app->get_num_args(); i++) {
-                SASSERT(is_app(ex_app->get_arg(i)));
-                app *arg = to_app(ex_app->get_arg(i));
-                extract_symbols(arg, m_util_s, m, alphabet);
-            }
+            throw_error("unsupported string operation");
         }
     }
 
@@ -429,7 +423,9 @@ namespace smt::noodler::util {
                 throw_error("we support only string literals in str.to_re");
             }
             nfa = conv_to_nfa(to_app(arg), m_util_s, m, alphabet);
-        } else if (m_util_s.re.is_concat(expr)) { // Handle concatenation.
+        } else if (m_util_s.re.is_concat(expr) // Handle regex concatenation.
+                || m_util_s.str.is_concat(expr) // Handle string concatenation.
+                ) {
             SASSERT(expr->get_num_args() > 0);
             nfa = conv_to_nfa(to_app(expr->get_arg(0)), m_util_s, m, alphabet);
             for (unsigned int i = 1; i < expr->get_num_args(); ++i) {
@@ -548,7 +544,7 @@ namespace smt::noodler::util {
             SASSERT(expr->get_num_parameters() == 1);
             nfa = create_word_nfa(expr->get_parameter(0).get_zstring());
         } else if(is_variable(expr, m_util_s)) { // Handle variable.
-            throw_error("variable should not occur here");
+            throw_error("variable in regexes are unsupported");
         } else {
             throw_error("unsupported operation");
         }

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -531,8 +531,6 @@ namespace smt::noodler::util {
             nfa = conv_to_nfa(to_app(child), m_util_s, m, alphabet);
             nfa.unify_initial();
             for (const auto& initial : nfa.initial) {
-                // FIXME: Cannot that introduce errors if there are transitions leading to the initial states?
-                //  Solution: Unify initial and add the unified initial as a final.
                 nfa.final.add(initial);
             }
         } else if (m_util_s.re.is_range(expression)) { // Handle range.

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -147,14 +147,14 @@ namespace smt::noodler::util {
 
     /**
      * Convert expression @p expr to NFA using hexadecimal values as symbols.
-     * @param[in] expr Expression to be converted to regex.
+     * @param[in] expression Expression to be converted to regex.
      * @param[in] m_util_s Seq util for AST.
      * @param[in] m AST manager.
      * @param[in] alphabet Alphabet to be used in re.allchar (SMT2: '.') expressions.
      * @param[in] make_complement Whether to make complement of the passed @p expr instead.
      * @return The resulting regex.
      */
-    [[nodiscard]] Mata::Nfa::Nfa conv_to_nfa(const app *expr, const seq_util& m_util_s, const ast_manager& m,
+    [[nodiscard]] Mata::Nfa::Nfa conv_to_nfa(const app *expression, const seq_util& m_util_s, const ast_manager& m,
                                              const std::set<uint32_t>& alphabet, bool make_complement = false);
 
     /**

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -30,6 +30,15 @@ namespace smt::noodler::util {
     using expr_pair_flag = std::tuple<expr_ref, expr_ref, bool>;
 
     /**
+     * Throws error and select which class to throw based on debug (if we are
+     * debugging, we do not want z3 to catch our error, if we are not debugging
+     * we want z3 to catch it and return unknown).
+     * 
+     * @param errMsg Error message
+     */
+    void throw_error(std::string errMsg);
+
+    /**
     Get variables from a given expression @p ex. Append to the output parameter @p res.
     @param ex Expression to be checked for variables.
     @param m_util_s Seq util for AST


### PR DESCRIPTION
This PR adds support for more string operations, specifically:
- regex complementation
- regex intersection
- regex ".+" which is in z3 represented specifically
- empty language
- language containing only epsilon
- counting loops "R{n,m}"

It also add function `throw_error` which we should use whenever we want to throw error in noodler. Based on debugging, it either throws std::runtime_error, which is not caught by Z3, so we can see what the problem is while debugging, otherwise it throws some internal Z3 exception, which Z3 can catch and return unknown.

I will run it on the benchmarks if it works correctly and then we can merge.